### PR TITLE
Update carbon-imageio to 2.0.6#1

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,7 +11,7 @@
     },
     {
       "name": "carbon-imageio",
-      "version>=": "2.0.6"
+      "version>=": "2.0.6#1"
     },
     {
       "name": "libsquish",


### PR DESCRIPTION
It includes a fix in openvdb dependency for compiling on clang 17+