### PR TITLE
EDR-1989 - Fix text corruption in oversized labels (16-bit text index overflow)

### DIFF
--- a/trinity/Font/Tr2FontMeasurer.cpp
+++ b/trinity/Font/Tr2FontMeasurer.cpp
@@ -782,8 +782,8 @@ void Tr2FontMeasurer::PrepareSprites( Tr2Sprite2dScene* renderer, const Vector2&
 	m_vertices = CCP_NEW( "Tr2FontMeasurer/m_vertices" ) Tr2Sprite2dD3DVertex[m_vertexCount];
 
 	m_indexCount = spriteCount * 6;
-	m_indices = CCP_NEW( "Tr2FontMeasurer/m_indices" ) unsigned short[m_indexCount];
-	unsigned short* curIndex = m_indices;
+	m_indices = CCP_NEW( "Tr2FontMeasurer/m_indices" ) unsigned int[m_indexCount];
+	unsigned int* curIndex = m_indices;
 
 	Tr2AtlasTexture* currentTexture = nullptr;
 
@@ -1072,7 +1072,7 @@ void Tr2FontMeasurer::SubmitSprites( Tr2Sprite2dScene* renderer )
 
 	Tr2Sprite2dD3DVertex* vertices;
 	unsigned int vertexCount;
-	unsigned short* indices;
+	unsigned int* indices;
 	unsigned int indexCount;
 	unsigned int vertexOffset = 0;
 
@@ -1083,11 +1083,11 @@ void Tr2FontMeasurer::SubmitSprites( Tr2Sprite2dScene* renderer )
 
 		unsigned int startSprite = entry.startSprite;
 		unsigned int spriteCount = entry.spriteCount;
-		unsigned short* adjustedIndices = nullptr;
+		unsigned int* adjustedIndices = nullptr;
 
 		if( spriteCount > maxSpriteCount )
 		{
-			adjustedIndices = CCP_NEW( "adjustedIndices" ) unsigned short[maxSpriteCount * 6];
+			adjustedIndices = CCP_NEW( "adjustedIndices" ) unsigned int[maxSpriteCount * 6];
 		}
 
 		// Ensure we don't submit too many vertices at once
@@ -1339,9 +1339,9 @@ void Tr2FontMeasurer::SetFadeBottomEnd( float val )
 	NotifyListenersOfChange();
 }
 
-unsigned short* Tr2FontMeasurer::AdjustIndicesIfNeeded( unsigned int startSprite, unsigned short* adjustedIndices, unsigned int indexCount, unsigned int vertexOffset )
+unsigned int* Tr2FontMeasurer::AdjustIndicesIfNeeded( unsigned int startSprite, unsigned int* adjustedIndices, unsigned int indexCount, unsigned int vertexOffset )
 {
-	unsigned short* indices;
+	unsigned int* indices;
 	if( startSprite > 0 && adjustedIndices )
 	{
 		indices = adjustedIndices;

--- a/trinity/Font/Tr2FontMeasurer.h
+++ b/trinity/Font/Tr2FontMeasurer.h
@@ -116,7 +116,7 @@ protected:
 	float CalcAlphaForHorizontal( float x );
 	float CalcAlphaForVertical( float y );
 
-	unsigned short* AdjustIndicesIfNeeded( unsigned int startSprite, unsigned short* adjustedIndices, unsigned int indexCount, unsigned int vertexOffset );
+	unsigned int* AdjustIndicesIfNeeded( unsigned int startSprite, unsigned int* adjustedIndices, unsigned int indexCount, unsigned int vertexOffset );
 
 protected:
 	std::string m_font;
@@ -169,7 +169,7 @@ protected:
 	FTC_ImageTypeRec m_imgTypeFallback;
 
 	struct Tr2Sprite2dD3DVertex* m_vertices;
-	unsigned short* m_indices;
+	unsigned int* m_indices;
 	unsigned int m_vertexCount;
 	unsigned int m_indexCount;
 

--- a/trinity/Sprite2d/Tr2Sprite2dScene.cpp
+++ b/trinity/Sprite2d/Tr2Sprite2dScene.cpp
@@ -997,7 +997,7 @@ bool Tr2Sprite2dScene::PrepareTriangleVerts( Tr2Sprite2dD3DVertex* destVerts, Tr
 	return true;
 }
 
-void Tr2Sprite2dScene::RenderTriangleVerts( Tr2Sprite2dD3DVertex* verticesSrc, unsigned int vertexCount, unsigned short* indices, unsigned short indexCount )
+void Tr2Sprite2dScene::RenderTriangleVerts( Tr2Sprite2dD3DVertex* verticesSrc, unsigned int vertexCount, unsigned short* indices, unsigned int indexCount )
 {
 	if( m_transformCurrent >= TR2_SS_MAX_TRANSFORM_COUNT - 1 )
 	{
@@ -1018,7 +1018,30 @@ void Tr2Sprite2dScene::RenderTriangleVerts( Tr2Sprite2dD3DVertex* verticesSrc, u
 	CopyIndicesWithOffset( indices, indexCount, vertexOffset );
 }
 
-void Tr2Sprite2dScene::RenderTriangleVerts( Tr2BufferAL& verticesSrc, unsigned int vertexCount, Tr2BufferAL& indices, unsigned short indexCount )
+// 32-bit index overload for large text batches: glyph index counts AND values can exceed 65535
+// (e.g. huge contract / acceleration-gate popups). The GPU index buffer is already 32-bit.
+void Tr2Sprite2dScene::RenderTriangleVerts( Tr2Sprite2dD3DVertex* verticesSrc, unsigned int vertexCount, unsigned int* indices, unsigned int indexCount )
+{
+	if( m_transformCurrent >= TR2_SS_MAX_TRANSFORM_COUNT - 1 )
+	{
+		// Buffers are full, kick off what we've got
+		IssueDrawCall();
+	}
+
+	// Offset applied to indices
+	int vertexOffset;
+
+	bool canRender = EnsureBufferSpace( vertexCount, indexCount, vertexOffset );
+	if( !canRender )
+	{
+		return;
+	}
+
+	ProcessVertices( verticesSrc, vertexCount );
+	CopyIndicesWithOffset( indices, indexCount, vertexOffset );
+}
+
+void Tr2Sprite2dScene::RenderTriangleVerts( Tr2BufferAL& verticesSrc, unsigned int vertexCount, Tr2BufferAL& indices, unsigned int indexCount )
 {
 	CCP_ASSERT( !m_captureDisplayList );
 
@@ -2478,7 +2501,7 @@ void Tr2Sprite2dScene::GrowCaptureVertexBuffer( unsigned int vertexCount )
 
 // Grow the index buffer used for capturing display lists. 'indexCount' is the number
 // indices that need to be added.
-void Tr2Sprite2dScene::GrowCaptureIndexBuffer( unsigned short indexCount )
+void Tr2Sprite2dScene::GrowCaptureIndexBuffer( unsigned int indexCount )
 {
 	CCP_STATS_ZONE( __FUNCTION__ );
 
@@ -2495,7 +2518,7 @@ void Tr2Sprite2dScene::GrowCaptureIndexBuffer( unsigned short indexCount )
 }
 
 // Copy indices to current index data, adding the given vertex offset
-void Tr2Sprite2dScene::CopyIndicesWithOffset( unsigned short* indices, unsigned short indexCount, int vertexOffset )
+void Tr2Sprite2dScene::CopyIndicesWithOffset( unsigned short* indices, unsigned int indexCount, int vertexOffset )
 {
 	unsigned short* curIndex = indices;
 	for( unsigned int i = 0; i < indexCount; ++i )
@@ -2508,7 +2531,21 @@ void Tr2Sprite2dScene::CopyIndicesWithOffset( unsigned short* indices, unsigned 
 	m_indexCount += indexCount;
 }
 
-bool Tr2Sprite2dScene::EnsureBufferSpace( unsigned int vertexCount, unsigned short indexCount, int& vertexOffset )
+// 32-bit index overload (see the 32-bit RenderTriangleVerts above). m_currentIndexData is uint32.
+void Tr2Sprite2dScene::CopyIndicesWithOffset( unsigned int* indices, unsigned int indexCount, int vertexOffset )
+{
+	unsigned int* curIndex = indices;
+	for( unsigned int i = 0; i < indexCount; ++i )
+	{
+		*m_currentIndexData = *curIndex + vertexOffset;
+		++m_currentIndexData;
+		++curIndex;
+	}
+
+	m_indexCount += indexCount;
+}
+
+bool Tr2Sprite2dScene::EnsureBufferSpace( unsigned int vertexCount, unsigned int indexCount, int& vertexOffset )
 {
 	if( m_captureDisplayList )
 	{

--- a/trinity/Sprite2d/Tr2Sprite2dScene.h
+++ b/trinity/Sprite2d/Tr2Sprite2dScene.h
@@ -115,15 +115,22 @@ public:
 		Tr2Sprite2dD3DVertex* verticesSrc,
 		unsigned int vertexCount,
 		unsigned short* indices,
-		unsigned short indexCount );
+		unsigned int indexCount );
 
 	void RenderTriangleVerts(
 		Tr2BufferAL& verticesSrc,
 		unsigned int vertexCount,
 		Tr2BufferAL& indices,
-		unsigned short indexCount );
+		unsigned int indexCount );
 
-	bool EnsureBufferSpace( unsigned int vertexCount, unsigned short indexCount, int& vertexOffset );
+	// 32-bit index overload for large text batches (glyph index counts/values can exceed 65535)
+	void RenderTriangleVerts(
+		Tr2Sprite2dD3DVertex* verticesSrc,
+		unsigned int vertexCount,
+		unsigned int* indices,
+		unsigned int indexCount );
+
+	bool EnsureBufferSpace( unsigned int vertexCount, unsigned int indexCount, int& vertexOffset );
 
 	bool IsCapturing() const;
 	bool StartCapture( ITr2SpriteObject* owner );
@@ -157,7 +164,8 @@ private:
 
 	// Copies vertices from source to destination and adds clipping and transform information
 	void ProcessVertices( Tr2Sprite2dD3DVertex* verticesSrc, unsigned int vertexCount );
-	void CopyIndicesWithOffset( unsigned short* indices, unsigned short indexCount, int vertexOffset );
+	void CopyIndicesWithOffset( unsigned short* indices, unsigned int indexCount, int vertexOffset );
+	void CopyIndicesWithOffset( unsigned int* indices, unsigned int indexCount, int vertexOffset );
 
 	void FlashDefaultTexture();
 	void RemoveFinishedCurveSets();
@@ -169,7 +177,7 @@ private:
 	void PrepareRenderContextForRendering( Tr2RenderContext& renderContext );
 	void CleanUpStacksAfterRender();
 	void PrepareStacksBeforeRender();
-	void GrowCaptureIndexBuffer( unsigned short indexCount );
+	void GrowCaptureIndexBuffer( unsigned int indexCount );
 	void GrowCaptureVertexBuffer( unsigned int vertexCount );
 
 


### PR DESCRIPTION
## Summary
Popup windows with a very large amount of text (e.g. contract confirmations with many items, "can't activate" acceleration-gate messages) render corrupt. The text sprite batch used 16-bit indices, which overflow once a single label exceeds 65,535 indices.

Should fix [EDR-1989](https://fenriscreations.atlassian.net/browse/EDR-1989).

## Root cause
EVE's font emits 2 quads per glyph = 12 indices/glyph with Text Shadow on, so a single label overflows the 16-bit index space at 65,535 / 12, i.e. about 5,461 visible glyphs. Two 16-bit bottlenecks:
1. Index count: `RenderTriangleVerts` / `EnsureBufferSpace` / `CopyIndicesWithOffset` / `GrowCaptureIndexBuffer` took `unsigned short indexCount`, truncating the `unsigned int` count the font passes (the ~5,461-glyph limit).
2. Index values: `Tr2FontMeasurer::m_indices` was `unsigned short`, so per-draw-call vertex indices wrap once a single-texture run exceeds 65,535 vertices (~8,191 glyphs with shadow).

UI text goes through the capture/display-list path, which does not split batches, so the whole label hits these 16-bit boundaries in one submission.

## Fix
Widen the text sprite index path to 32-bit:
- Index counts `unsigned short` -> `unsigned int` in `RenderTriangleVerts` (both overloads), `EnsureBufferSpace`, `CopyIndicesWithOffset`, `GrowCaptureIndexBuffer`.
- Index values in `Tr2FontMeasurer` (`m_indices`, `AdjustIndicesIfNeeded`) -> `unsigned int`, submitted via new 32-bit `RenderTriangleVerts` / `CopyIndicesWithOffset` overloads. The existing 16-bit overloads are kept for the other sprite types (frames, lines, brackets) that pass 16-bit index arrays, so their callers are untouched.

The GPU index buffer is already 32-bit (`m_indexBuffer.Create(indexCount, 4)`), so no GPU format change is needed; this only stops the CPU-side truncation before the data reaches the already-32-bit buffer.
