### PR TITLE
fix texture mip flicker on instanced meshes, by reporting screen size per pass and never reporting 0

### DIFF
--- a/trinity/Eve/EveInstancedMeshManager.cpp
+++ b/trinity/Eve/EveInstancedMeshManager.cpp
@@ -985,9 +985,12 @@ void EveInstancedMeshManager::ReportUsedScreenSizes() const
 {
 	for( auto& [mesh, meshInfo] : m_meshInstances )
 	{
-		if( auto meshData = mesh.geometry->GetMeshLod( mesh.meshIndex, 0 ) )
+		if( meshInfo.maxScreenSize > 0.0f )
 		{
-			meshInfo.material->UsedWithScreenSize( meshInfo.maxScreenSize, meshInfo.radius, meshData->m_uvDensities );
+			if( auto meshData = mesh.geometry->GetMeshLod( mesh.meshIndex, 0 ) )
+			{
+				meshInfo.material->UsedWithScreenSize( meshInfo.maxScreenSize, meshInfo.radius, meshData->m_uvDensities );
+			}
 		}
 	}
 }

--- a/trinity/Eve/EveSpaceScene.cpp
+++ b/trinity/Eve/EveSpaceScene.cpp
@@ -1517,6 +1517,8 @@ void EveSpaceScene::GatherBatches( bool includeDistortions, Tr2RenderContext& re
 
 	m_instancedMeshManager->GetBatches( m_updateContext.GetFrustum(), m_updateContext.GetInvLodFactor(), { { TRIBATCHTYPE_OPAQUE, *m_primaryBatches[TRIBATCHTYPE_OPAQUE] }, { TRIBATCHTYPE_DECAL, *m_primaryBatches[TRIBATCHTYPE_DECAL] }, { TRIBATCHTYPE_ADDITIVE, *m_primaryBatches[TRIBATCHTYPE_ADDITIVE] }, { TRIBATCHTYPE_DEPTH, *m_primaryBatches[TRIBATCHTYPE_DEPTH] }, { TRIBATCHTYPE_DISTORTION, *m_primaryBatches[TRIBATCHTYPE_DISTORTION] } } );
 
+	m_instancedMeshManager->ReportUsedScreenSizes();
+
 	FinalizeBatches( m_primaryBatches );
 
 	UpdateShLighting( allObjects );
@@ -1905,6 +1907,8 @@ void EveSpaceScene::RenderReflectionPass( Tr2GpuResourcePool& gpuResourcePool, T
 												   { TRIBATCHTYPE_ADDITIVE, *m_secondaryBatches[TRIBATCHTYPE_ADDITIVE] },
 												   { TRIBATCHTYPE_DEPTH, *m_secondaryBatches[TRIBATCHTYPE_DEPTH] },
 											   } ) > 0;
+
+				m_instancedMeshManager->ReportUsedScreenSizes();
 
 				if( hasFog || !visibleRenderables.empty() || hasInstancedBatches )
 				{


### PR DESCRIPTION
Fix texture-mip flicker on instanced meshes (PLAT-11597): report screen sizes per pass and never report 0. passes that culled a mesh were overwriting the frame's screen size, flapping the streamed mip at reflection-probe cadence.