### PR TITLE
Fixed stray dx12 hook in Tr2ResourceHelper from allowing devices to r…

### DIFF
--- a/trinity/TriDevice12.cpp
+++ b/trinity/TriDevice12.cpp
@@ -220,11 +220,11 @@ void TriDevice::HandleRenderTick( Be::Time realTime, Be::Time simTime )
 					{
 						CCP_LOGERR( "[DRED] Commandlist completed %d of %d commands", lastCompletedOp, pNode->BreadcrumbCount );
 
-						UINT firstOp = std::max<UINT>( lastCompletedOp - 100, 0 );
+						UINT firstOp = lastCompletedOp > 100 ? lastCompletedOp - 100 : 0;
 						UINT lastOp = std::min<UINT>( lastCompletedOp + 20, UINT( pNode->BreadcrumbCount ) - 1 );
 
 						contextStrings.clear();
-						for( UINT breadcrumbContext = firstOp; breadcrumbContext < pNode->BreadcrumbContextsCount; ++breadcrumbContext )
+						for( UINT breadcrumbContext = 0; breadcrumbContext < pNode->BreadcrumbContextsCount; ++breadcrumbContext )
 						{
 							const D3D12_DRED_BREADCRUMB_CONTEXT& context = pNode->pBreadcrumbContexts[breadcrumbContext];
 							contextStrings[context.BreadcrumbIndex] = context.pContextString;

--- a/trinity/trinity.cpp
+++ b/trinity/trinity.cpp
@@ -173,6 +173,7 @@ PyObject* InitializeForPython()
 
 extern bool g_requestDeviceDebugLayer;
 extern bool g_requestDebugMarkers;
+extern bool g_requestDred;
 extern bool g_gpuTimersEnabled;
 bool g_bindlessRenderingEnabled = true;
 TRI_REGISTER_SETTING( "bindlessRenderingEnabled", g_bindlessRenderingEnabled );
@@ -239,6 +240,12 @@ void InitializeTrinity()
 	if( !debugArg.empty() )
 	{
 		g_requestDeviceDebugLayer = debugArg == L"1";
+	}
+
+	auto dredArg = BeOS->GetStartupArgValue( L"dred" );
+	if( !dredArg.empty() )
+	{
+		g_requestDred = dredArg == L"1";
 	}
 
 	auto markersArg = BeOS->GetStartupArgValue( L"gpuMarkers" );

--- a/trinityal/ALResult.cpp
+++ b/trinityal/ALResult.cpp
@@ -9,6 +9,7 @@ bool g_requestDeviceDebugLayer = true;
 #else
 bool g_requestDeviceDebugLayer = false;
 #endif
+bool g_requestDred = false;
 ICrashReporter* TrinityALCrashes = nullptr;
 
 

--- a/trinityal/dx12/Tr2PrimaryRenderContextDx12.cpp
+++ b/trinityal/dx12/Tr2PrimaryRenderContextDx12.cpp
@@ -37,7 +37,7 @@ CCP_STATS_DECLARE( dx12GpuMemoryBudgetLocal, "Trinity/AL/gpuMemory/budgetLocal",
 
 namespace
 {
-void EnableDred()
+bool EnableDred()
 {
 	CComPtr<ID3D12DeviceRemovedExtendedDataSettings1> pDredSettings;
 	if( SUCCEEDED( D3D12GetDebugInterface( IID_PPV_ARGS( &pDredSettings ) ) ) )
@@ -45,7 +45,9 @@ void EnableDred()
 		// Turn on auto-breadcrumbs and page fault reporting.
 		pDredSettings->SetAutoBreadcrumbsEnablement( D3D12_DRED_ENABLEMENT_FORCED_ON );
 		pDredSettings->SetPageFaultEnablement( D3D12_DRED_ENABLEMENT_FORCED_ON );
+		return true;
 	}
+	return false;
 }
 
 bool EnableDebugLayer()
@@ -300,9 +302,10 @@ ALResult Tr2PrimaryRenderContextAL::CreateDevice(
 	m_focusWindow = focusWindow;
 	m_adapter = adapter;
 
+	bool dredEnabled = false;
 	if( g_requestDred || g_requestDeviceDebugLayer )
 	{
-		EnableDred();
+		dredEnabled = EnableDred();
 	}
 
 	bool hasDebugLayer = false;
@@ -315,7 +318,7 @@ ALResult Tr2PrimaryRenderContextAL::CreateDevice(
 	CComPtr<IDXGIAdapter1> dxgiAdapter;
 	CComPtr<IDXGIOutput> output;
 
-	if( !m_gpuCrashTracker )
+	if( !m_gpuCrashTracker && !dredEnabled )
 	{
 		m_gpuCrashTracker = new TrinityALImpl::GpuCrashTracker();
 	}
@@ -342,15 +345,19 @@ ALResult Tr2PrimaryRenderContextAL::CreateDevice(
 		CR_RETURN_HR( CreateDevice( dxgiAdapter, D3D_FEATURE_LEVEL_12_0, device ) );
 	}
 
-	if( !m_gpuCrashTracker->IsValid() )
+	if( m_gpuCrashTracker )
 	{
-		m_gpuCrashTracker = nullptr;
-	}
-	else if( !hasDebugLayer )
-	{
-		// Aftermath device tracking is incompatible with the debug layer; the failed
-		// GFSDK_Aftermath_DX12_Initialize leaks a device reference that blocks device-lost recovery.
-		m_gpuCrashTracker->Initialize( device );
+		if( !m_gpuCrashTracker->IsValid() )
+		{
+			delete m_gpuCrashTracker;
+			m_gpuCrashTracker = nullptr;
+		}
+		else if( !hasDebugLayer )
+		{
+			// Aftermath device tracking is incompatible with the debug layer; the failed
+			// GFSDK_Aftermath_DX12_Initialize leaks a device reference that blocks device-lost recovery.
+			m_gpuCrashTracker->Initialize( device );
+		}
 	}
 
 	if( hasDebugLayer )

--- a/trinityal/dx12/Tr2PrimaryRenderContextDx12.cpp
+++ b/trinityal/dx12/Tr2PrimaryRenderContextDx12.cpp
@@ -15,6 +15,7 @@
 
 extern bool g_requestDeviceDebugLayer;
 extern bool g_requestDebugMarkers;
+extern bool g_requestDred;
 bool g_gatherPipelineStatistics = false;
 extern ICrashReporter* TrinityALCrashes;
 
@@ -36,7 +37,7 @@ CCP_STATS_DECLARE( dx12GpuMemoryBudgetLocal, "Trinity/AL/gpuMemory/budgetLocal",
 
 namespace
 {
-bool EnableDebugLayer()
+void EnableDred()
 {
 	CComPtr<ID3D12DeviceRemovedExtendedDataSettings1> pDredSettings;
 	if( SUCCEEDED( D3D12GetDebugInterface( IID_PPV_ARGS( &pDredSettings ) ) ) )
@@ -45,8 +46,10 @@ bool EnableDebugLayer()
 		pDredSettings->SetAutoBreadcrumbsEnablement( D3D12_DRED_ENABLEMENT_FORCED_ON );
 		pDredSettings->SetPageFaultEnablement( D3D12_DRED_ENABLEMENT_FORCED_ON );
 	}
+}
 
-
+bool EnableDebugLayer()
+{
 	CComPtr<ID3D12Debug> debugInterface;
 	CComPtr<ID3D12Debug1> debugInterface1;
 	if( SUCCEEDED( D3D12GetDebugInterface( IID_PPV_ARGS( &debugInterface ) ) ) )
@@ -297,6 +300,11 @@ ALResult Tr2PrimaryRenderContextAL::CreateDevice(
 	m_focusWindow = focusWindow;
 	m_adapter = adapter;
 
+	if( g_requestDred || g_requestDeviceDebugLayer )
+	{
+		EnableDred();
+	}
+
 	bool hasDebugLayer = false;
 	if( g_requestDeviceDebugLayer )
 	{
@@ -338,8 +346,10 @@ ALResult Tr2PrimaryRenderContextAL::CreateDevice(
 	{
 		m_gpuCrashTracker = nullptr;
 	}
-	else
+	else if( !hasDebugLayer )
 	{
+		// Aftermath device tracking is incompatible with the debug layer; the failed
+		// GFSDK_Aftermath_DX12_Initialize leaks a device reference that blocks device-lost recovery.
 		m_gpuCrashTracker->Initialize( device );
 	}
 

--- a/trinityal/dx12/Tr2ResourceHelper.cpp
+++ b/trinityal/dx12/Tr2ResourceHelper.cpp
@@ -120,9 +120,14 @@ void Tr2ResourceHelper::Destroy( Tr2PrimaryRenderContextAL& renderContext )
 		RELEASE_LATER( &renderContext, m_gpuResource.resource );
 		m_gpuResource = Resource();
 	}
-	for( auto it = begin( m_resources ); it != end( m_resources ); ++it )
+	if( m_mapped.resource )
 	{
-		RELEASE_LATER( &renderContext, it->resource );
+		RELEASE_LATER( &renderContext, m_mapped.resource );
+		m_mapped = Resource();
+	}
+	for( auto& resource : m_resources )
+	{
+		RELEASE_LATER( &renderContext, resource.resource );
 	}
 	m_resources.clear();
 }
@@ -271,6 +276,7 @@ ALResult Tr2ResourceHelper::UpdateBuffer( Tr2LockType::Type lockType, uint32_t o
 		}
 
 		RELEASE_LATER( renderContext.m_ownerDevice, m_mapped.resource );
+		m_mapped = Resource();
 
 		return S_OK;
 	}


### PR DESCRIPTION
Tr2ResourceHelper leaked one upload-scratch reference via m_mapped (Destroy never cleared it; the synchronized UpdateBuffer path left it set), keeping the removed ID3D12Device alive so D3D12CreateDevice returned it forever and device-lost recovery looped indefinitely.