### PR TITLE
M4 vulkan trinity al

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ CMakeUserPresets.json
 .cmake-build*
 cmake-build*
 .claude/*
+
+### Dear ImGui ###
+# Per-user window layout, saved by ImGui into whatever directory its host was run from.
+# Trinity does not use ImGui itself, but a project that consumes this build tree can be run
+# from this checkout, and the file then shows up as untracked content in the superproject.
+imgui.ini

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,5 @@
 	url = git@github.com:microsoft/vcpkg.git
 [submodule "vendor/github.com/carbonengine/vcpkg-registry"]
 	path = vendor/github.com/carbonengine/vcpkg-registry
-	url = git@github.com:carbonengine/vcpkg-registry.git
+	url = git@github.com:ccpshanghai/vcpkg-registry.git
+	branch = mobile-exp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,13 +19,22 @@ else()
         option(BUILD_DX11 "Build dx11." OFF)
         option(BUILD_DX12 "Build dx12." OFF)
         # vulkan-headers and vulkan-memory-allocator are core, non-feature
-        # dependencies in vcpkg.json, so the backend itself widens the closure by
-        # nothing. The "vulkan" feature exists only for directx-dxc, which the
-        # TrinityALTest_vulkan shader step needs to emit SPIR-V -- and which is
-        # otherwise gated behind dx11/dx12/shader-compiler, all OFF here.
-        # directx-dxc is a public port, so this preserves the property that the
-        # Vulkan configuration is the one Windows configuration that builds outside
-        # the CCP network.
+        # dependencies in vcpkg.json, so the backend's own compile surface widens the
+        # closure by nothing. The "vulkan" manifest feature carries exactly two ports:
+        #
+        #   directx-dxc   -- the TrinityALTest_vulkan shader step needs it to emit
+        #                    SPIR-V (fxc cannot), and it is otherwise gated behind
+        #                    dx11/dx12/shader-compiler, all OFF here.
+        #   vulkan-loader -- the import library for the vk* entry points. The headers
+        #                    ship no library, which nothing noticed while Phase 1 built
+        #                    the backend as a static archive and linked no executable
+        #                    against it (85 unresolved vk* symbols; see
+        #                    docs/spikes/M4-phase2a-test-harness.md §4a).
+        #
+        # Both are public ports from the vendored default microsoft/vcpkg registry, so
+        # this preserves the property that the Vulkan configuration is the one Windows
+        # configuration that builds outside the CCP network -- which is the argument to
+        # re-check against this list, not against this comment, before adding a third.
         option(BUILD_VULKAN "Build Vulkan." OFF)
     elseif(APPLE)
         option(BUILD_METAL "Build Metal." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,14 @@ else()
     if(WIN32)
         option(BUILD_DX11 "Build dx11." OFF)
         option(BUILD_DX12 "Build dx12." OFF)
-        # No VCPKG_MANIFEST_FEATURES entry: vulkan-headers and
-        # vulkan-memory-allocator are already core, non-feature dependencies in
-        # vcpkg.json, so a Vulkan build widens the dependency closure by nothing.
+        # vulkan-headers and vulkan-memory-allocator are core, non-feature
+        # dependencies in vcpkg.json, so the backend itself widens the closure by
+        # nothing. The "vulkan" feature exists only for directx-dxc, which the
+        # TrinityALTest_vulkan shader step needs to emit SPIR-V -- and which is
+        # otherwise gated behind dx11/dx12/shader-compiler, all OFF here.
+        # directx-dxc is a public port, so this preserves the property that the
+        # Vulkan configuration is the one Windows configuration that builds outside
+        # the CCP network.
         option(BUILD_VULKAN "Build Vulkan." OFF)
     elseif(APPLE)
         option(BUILD_METAL "Build Metal." OFF)
@@ -36,6 +41,10 @@ else()
 
     if (BUILD_METAL)
         list(APPEND VCPKG_MANIFEST_FEATURES "metal")
+    endif()
+
+    if (BUILD_VULKAN)
+        list(APPEND VCPKG_MANIFEST_FEATURES "vulkan")
     endif()
 
     if (BUILD_SHADER_COMPILER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,13 @@ endif()
 
 project(carbon-trinity VERSION 1.0.0)
 
+# Enables CTest at the scope every add_subdirectory() below inherits from, so a
+# ctest run from the build root can see tests registered by any subdirectory
+# (currently trinityal/tests/CMakeLists.txt's TrinityALTest_vulkan). This is
+# additive only -- it defines no targets and does not touch BUILD_TESTING --
+# so it changes nothing about what dx11, dx12, or metal configurations build.
+enable_testing()
+
 if (BUILD_FOR_PYTHON_2)
     if(NOT DEFINED ENV{CCP_EVE_PERFORCE_BRANCH_PATH})
         message(FATAL_ERROR "Missing required environment variable CCP_EVE_PERFORCE_BRANCH_PATH")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ else()
     if(WIN32)
         option(BUILD_DX11 "Build dx11." OFF)
         option(BUILD_DX12 "Build dx12." OFF)
+        # No VCPKG_MANIFEST_FEATURES entry: vulkan-headers and
+        # vulkan-memory-allocator are already core, non-feature dependencies in
+        # vcpkg.json, so a Vulkan build widens the dependency closure by nothing.
+        option(BUILD_VULKAN "Build Vulkan." OFF)
     elseif(APPLE)
         option(BUILD_METAL "Build Metal." OFF)
     endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -173,6 +173,90 @@
         "VCPKG_TARGET_TRIPLET": "x64-osx-trinitydev",
         "VCPKG_HOST_TRIPLET": "x64-osx-trinitydev"
       }
+    },
+    {
+      "name": "arm64-android",
+      "inherits": "windows",
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "Android",
+        "CMAKE_SYSTEM_VERSION": "31",
+        "ANDROID_ABI": "arm64-v8a",
+        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/vendor/github.com/carbonengine/vcpkg-registry/toolchains/arm64-android-triplet.cmake"
+      },
+      "hidden": true
+    },
+    {
+      "name": "arm64-android-release",
+      "inherits": "arm64-android",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "VCPKG_TARGET_TRIPLET": "arm64-android-release",
+        "VCPKG_HOST_TRIPLET": "x64-windows-release"
+      }
+    },
+    {
+      "name": "arm64-android-debug",
+      "inherits": "arm64-android",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "VCPKG_TARGET_TRIPLET": "arm64-android-debug",
+        "VCPKG_HOST_TRIPLET": "x64-windows-release"
+      }
+    },
+    {
+      "name": "arm64-ios",
+      "inherits": "osx",
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "iOS",
+        "CMAKE_OSX_ARCHITECTURES": "arm64",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "26.0",
+        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/vendor/github.com/carbonengine/vcpkg-registry/toolchains/arm64-ios-triplet.cmake"
+      },
+      "hidden": true
+    },
+    {
+      "name": "arm64-ios-release",
+      "inherits": "arm64-ios",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "VCPKG_TARGET_TRIPLET": "arm64-ios-release",
+        "VCPKG_HOST_TRIPLET": "arm64-osx-release"
+      }
+    },
+    {
+      "name": "arm64-ios-debug",
+      "inherits": "arm64-ios",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "VCPKG_TARGET_TRIPLET": "arm64-ios-debug",
+        "VCPKG_HOST_TRIPLET": "arm64-osx-release"
+      }
+    },
+    {
+      "name": "arm64-ios-simulator",
+      "inherits": "arm64-ios",
+      "cacheVariables": {
+        "CMAKE_OSX_SYSROOT": "iphonesimulator"
+      },
+      "hidden": true
+    },
+    {
+      "name": "arm64-ios-simulator-release",
+      "inherits": "arm64-ios-simulator",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "VCPKG_TARGET_TRIPLET": "arm64-ios-simulator-release",
+        "VCPKG_HOST_TRIPLET": "arm64-osx-release"
+      }
+    },
+    {
+      "name": "arm64-ios-simulator-debug",
+      "inherits": "arm64-ios-simulator",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "VCPKG_TARGET_TRIPLET": "arm64-ios-simulator-debug",
+        "VCPKG_HOST_TRIPLET": "arm64-osx-release"
+      }
     }
   ]
 }

--- a/shadercompiler/Platforms.h
+++ b/shadercompiler/Platforms.h
@@ -10,6 +10,7 @@ enum Platform
 	PLATFORM_DX11 = 2,
 
 	PLATFORM_DX12 = 6,
+	PLATFORM_VULKAN = 7,
 
 	PLATFORM_METAL = 10,
 
@@ -23,6 +24,8 @@ inline bool IsValidPlatform( Platform platform )
 	case PLATFORM_DX11:
 		return true;
 	case PLATFORM_DX12:
+		return true;
+	case PLATFORM_VULKAN:
 		return true;
 	case PLATFORM_METAL:
 		return true;
@@ -39,6 +42,8 @@ inline const char* GetPlatformShortName( Platform platform )
 		return "dx11";
 	case PLATFORM_DX12:
 		return "dx12";
+	case PLATFORM_VULKAN:
+		return "vulkan";
 	case PLATFORM_METAL:
 		return "mtl";
 	default:
@@ -54,6 +59,8 @@ inline const char* GetPlatformLongName( Platform platform )
 		return "DirectX 11";
 	case PLATFORM_DX12:
 		return "DirectX 12";
+	case PLATFORM_VULKAN:
+		return "Vulkan";
 	case PLATFORM_METAL:
 		return "Metal";
 	default:
@@ -69,6 +76,8 @@ inline const char* GetPlatformIdString( Platform platform )
 		return "2";
 	case PLATFORM_DX12:
 		return "6";
+	case PLATFORM_VULKAN:
+		return "7";
 	case PLATFORM_METAL:
 		return "10";
 	default:

--- a/trinity/CMakeLists.txt
+++ b/trinity/CMakeLists.txt
@@ -2017,6 +2017,20 @@ if(WIN32)
         set_shared_trinity_properties(${TRINITY_DX12_TARGET_NAME})
     endif()
 
+    if (BUILD_VULKAN)
+
+        set(TRINITY_VULKAN_TARGET_NAME trinity_vulkan)
+
+        ccp_add_library(${TRINITY_VULKAN_TARGET_NAME} SHARED)
+        target_compile_definitions(${TRINITY_VULKAN_TARGET_NAME}
+            PRIVATE
+                TRINITY_PLATFORM=TRINITY_VULKAN
+                TRINITYNAME=_trinity_vulkan
+        )
+        target_link_libraries(${TRINITY_VULKAN_TARGET_NAME} PRIVATE TrinityAL_vulkan)
+        set_shared_trinity_properties(${TRINITY_VULKAN_TARGET_NAME})
+    endif()
+
 elseif(APPLE)
     if(BUILD_METAL)
         enable_language(OBJCXX)

--- a/trinity/Tr2RenderContext_Blue.cpp
+++ b/trinity/Tr2RenderContext_Blue.cpp
@@ -337,6 +337,60 @@ const Be::ClassInfo* Tr2PrimaryRenderContext::ExposeToBlue()
 			GetBackBufferFormat,
 			"Returns the PixelFormat of the default back buffer" )
 
+		MAP_METHOD_AND_WRAP(
+			"GetNativeCommandList",
+			GetNativeCommandList,
+			"Returns this context's native command list as an integer.\n"
+			"\n"
+			"For hosting an immediate-mode UI (ImGui) inside Trinity's frame from\n"
+			"Python: the renderer ships as a CPython extension module with no C++\n"
+			"exports, so a C++ UI layer cannot link against it and the handle has to\n"
+			"cross through Python.\n"
+			"\n"
+			"This is NOT a liveness check. The DX12 backend allocates its command list\n"
+			"once and reuses it, so the value is non-zero outside the frame too —\n"
+			"measured identical before, during and after a pump. Record into it only\n"
+			"from inside a TriStepPythonCB callback, and gate on being there rather\n"
+			"than on this value.\n"
+			"\n"
+			"0 on every backend other than DX12, which is the one thing zero does mean." )
+
+		MAP_METHOD_AND_WRAP(
+			"GetNativeDevice",
+			GetNativeDevice,
+			"Returns the ID3D12Device as an integer, or 0 off DX12.\n"
+			"\n"
+			"Needed by ImGui's DX12 backend at init, and by the same route as the command\n"
+			"list: there is no C++ path off this engine." )
+
+		MAP_METHOD_AND_WRAP(
+			"GetNativeSrvHeap",
+			GetNativeSrvHeap,
+			"Returns the shader-visible SRV/UAV descriptor heap as an integer, 0 off DX12.\n"
+			"\n"
+			"This is the heap Trinity binds, exposed so a hosted UI can put that binding\n"
+			"back after it has drawn — not a heap to draw out of. The host brings its own\n"
+			"SRV heap for ImGui's font descriptor and binds it before drawing, and\n"
+			"SetDescriptorHeaps replaces the whole binding rather than adding to it, so\n"
+			"Trinity's heaps have to be restored afterwards. See GetNativeSamplerHeap." )
+
+		MAP_METHOD_AND_WRAP(
+			"GetNativeCommandQueue",
+			GetNativeCommandQueue,
+			"Returns the direct ID3D12CommandQueue as an integer, or 0 off DX12.\n"
+			"\n"
+			"ImGui's DX12 backend uploads its font texture through a command queue at\n"
+			"init; without one that upload has nowhere to go." )
+
+		MAP_METHOD_AND_WRAP(
+			"GetNativeSamplerHeap",
+			GetNativeSamplerHeap,
+			"Returns the shader-visible sampler descriptor heap as an integer, 0 off DX12.\n"
+			"\n"
+			"Needed to put the binding back after a hosted UI has drawn:\n"
+			"SetDescriptorHeaps replaces the whole binding rather than adding to it, so\n"
+			"restoring only the SRV heap leaves later draws without samplers." )
+
 	EXPOSURE_END()
 }
 

--- a/trinity/Tr2Renderer.cpp
+++ b/trinity/Tr2Renderer.cpp
@@ -1502,7 +1502,7 @@ bool Tr2Renderer::GetGeometryShaderSupport()
 
 	Tr2ShaderAL shader;
 	return SUCCEEDED( shader.Create( GEOMETRY_SHADER, bytecode, Tr2ShaderSignatureAL(), "", renderContext ) );
-#elif TRINITY_PLATFORM == TRINITY_DIRECTX12
+#elif TRINITY_PLATFORM == TRINITY_DIRECTX12 || TRINITY_PLATFORM == TRINITY_VULKAN
 	return true;
 #else
 	return false;

--- a/trinityal/CMakeLists.txt
+++ b/trinityal/CMakeLists.txt
@@ -322,6 +322,40 @@ set(_SOURCES
     stub/Tr2VideoAdapterInfoALStub.h
     stub/upscaling/Tr2UpscalingALStub.cpp
     stub/upscaling/Tr2UpscalingALStub.h
+    vulkan/Tr2BufferALVulkan.cpp
+    vulkan/Tr2BufferALVulkan.h
+    vulkan/Tr2CapsALVulkan.h
+    vulkan/Tr2ConstantBufferALVulkan.cpp
+    vulkan/Tr2ConstantBufferALVulkan.h
+    vulkan/Tr2FenceALVulkan.h
+    vulkan/Tr2GpuTimerALVulkan.h
+    vulkan/Tr2OcclusionQueryALVulkan.h
+    vulkan/Tr2PipelineStatsQueryALVulkan.cpp
+    vulkan/Tr2PipelineStatsQueryALVulkan.h
+    vulkan/Tr2PrimaryRenderContextVulkan.cpp
+    vulkan/Tr2PrimaryRenderContextVulkan.h
+    vulkan/Tr2RenderContextVulkan.cpp
+    vulkan/Tr2RenderContextVulkan.h
+    vulkan/Tr2ResourceSetALVulkan.cpp
+    vulkan/Tr2ResourceSetALVulkan.h
+    vulkan/Tr2SamplerStateALVulkan.cpp
+    vulkan/Tr2SamplerStateALVulkan.h
+    vulkan/Tr2ShaderALVulkan.cpp
+    vulkan/Tr2ShaderALVulkan.h
+    vulkan/Tr2ShaderProgramALVulkan.cpp
+    vulkan/Tr2ShaderProgramALVulkan.h
+    vulkan/Tr2SwapChainALVulkan.h
+    vulkan/Tr2TextureALVulkan.cpp
+    vulkan/Tr2TextureALVulkan.h
+    vulkan/Tr2VertexLayoutALVulkan.cpp
+    vulkan/Tr2VertexLayoutALVulkan.h
+    vulkan/Tr2VideoAdapterInfoALVulkan.cpp
+    vulkan/Tr2VideoAdapterInfoALVulkan.h
+    vulkan/upscaling/Tr2UpscalingALVulkan.cpp
+    vulkan/upscaling/Tr2UpscalingALVulkan.h
+    vulkan/UtilitiesVulkan.cpp
+    vulkan/UtilitiesVulkan.h
+    vulkan/VkResult.h
 )
 
 # Ensure that we have a sane file grouping for XCode and VS project files

--- a/trinityal/CMakeLists.txt
+++ b/trinityal/CMakeLists.txt
@@ -515,6 +515,27 @@ if(WIN32)
         set_shared_trinityal_properties(dx12)
     endif()
 
+    if (BUILD_VULKAN)
+
+        #[[
+            Modelled on TrinityAL_stub, NOT on TrinityAL_dx11/dx12. Those targets
+            link the NVIDIA Streamline/Aftermath, AMD FidelityFX and Intel XeSS
+            packages, and their vcpkg features drag in fxc, which fetches from an
+            internal-only host. Keeping this target clear of all of them is what
+            lets a Vulkan configuration build outside the CCP network -- the only
+            Windows configuration that can. Do not "align" it with dx12 later.
+        ]]
+        find_package(VulkanHeaders CONFIG REQUIRED)
+        find_package(VulkanMemoryAllocator CONFIG REQUIRED)
+
+        ccp_add_library(TrinityAL_vulkan STATIC)
+        target_compile_definitions(TrinityAL_vulkan PUBLIC TRINITY_PLATFORM=TRINITY_VULKAN)
+        target_link_libraries(TrinityAL_vulkan PUBLIC
+                                                    Vulkan::Headers
+                                                    GPUOpen::VulkanMemoryAllocator)
+        set_shared_trinityal_properties(vulkan)
+    endif()
+
 elseif(APPLE)
     
     if(BUILD_METAL)

--- a/trinityal/CMakeLists.txt
+++ b/trinityal/CMakeLists.txt
@@ -529,7 +529,7 @@ if(WIN32)
         find_package(VulkanMemoryAllocator CONFIG REQUIRED)
 
         ccp_add_library(TrinityAL_vulkan STATIC)
-        target_compile_definitions(TrinityAL_vulkan PUBLIC TRINITY_PLATFORM=TRINITY_VULKAN)
+        target_compile_definitions(TrinityAL_vulkan PUBLIC TRINITY_PLATFORM=TRINITY_VULKAN VK_USE_PLATFORM_WIN32_KHR)
         target_link_libraries(TrinityAL_vulkan PUBLIC
                                                     Vulkan::Headers
                                                     GPUOpen::VulkanMemoryAllocator)

--- a/trinityal/CMakeLists.txt
+++ b/trinityal/CMakeLists.txt
@@ -538,7 +538,8 @@ if(WIN32)
         target_link_libraries(TrinityAL_vulkan PUBLIC
                                                     Vulkan::Headers
                                                     GPUOpen::VulkanMemoryAllocator
-                                                    Vulkan::Loader)
+                                                    Vulkan::Loader
+                                                    dxgi)
         set_shared_trinityal_properties(vulkan)
     endif()
 

--- a/trinityal/CMakeLists.txt
+++ b/trinityal/CMakeLists.txt
@@ -524,15 +524,21 @@ if(WIN32)
             internal-only host. Keeping this target clear of all of them is what
             lets a Vulkan configuration build outside the CCP network -- the only
             Windows configuration that can. Do not "align" it with dx12 later.
+            vulkan-loader is the one addition here: it is a public port (built
+            from the upstream KhronosGroup/Vulkan-Loader release, matched to the
+            vulkan-headers version pinned above), so it does not reopen that
+            property.
         ]]
         find_package(VulkanHeaders CONFIG REQUIRED)
         find_package(VulkanMemoryAllocator CONFIG REQUIRED)
+        find_package(VulkanLoader CONFIG REQUIRED)
 
         ccp_add_library(TrinityAL_vulkan STATIC)
         target_compile_definitions(TrinityAL_vulkan PUBLIC TRINITY_PLATFORM=TRINITY_VULKAN VK_USE_PLATFORM_WIN32_KHR)
         target_link_libraries(TrinityAL_vulkan PUBLIC
                                                     Vulkan::Headers
-                                                    GPUOpen::VulkanMemoryAllocator)
+                                                    GPUOpen::VulkanMemoryAllocator
+                                                    Vulkan::Loader)
         set_shared_trinityal_properties(vulkan)
     endif()
 

--- a/trinityal/dx11/Tr2RenderContextDx11.h
+++ b/trinityal/dx11/Tr2RenderContextDx11.h
@@ -277,6 +277,34 @@ private:
 	SharedConstantBuffer m_sharedConstantBuffers[Tr2RenderContextEnum::SHADER_TYPE_COUNT * CB_SLOT_COUNT];
 
 public:
+	// See the DX12 backend for what this is for. There is no DX12 command list
+	// here, and 0 is the documented "not now" value.
+	uint64_t GetNativeCommandList() const
+	{
+		return 0;
+	}
+
+	// See the DX12 backend. No DX12 device or descriptor heap here.
+	uint64_t GetNativeDevice() const
+	{
+		return 0;
+	}
+
+	uint64_t GetNativeSrvHeap() const
+	{
+		return 0;
+	}
+
+	uint64_t GetNativeCommandQueue() const
+	{
+		return 0;
+	}
+
+	uint64_t GetNativeSamplerHeap() const
+	{
+		return 0;
+	}
+
 	uint32_t ComputeVertexCount( uint32_t primitiveCount ) const throw();
 
 	CComPtr<ID3D11Device> m_secondaryDevice11;

--- a/trinityal/dx12/Tr2PrimaryRenderContextDx12.h
+++ b/trinityal/dx12/Tr2PrimaryRenderContextDx12.h
@@ -118,6 +118,39 @@ public:
 
 
 	ID3D12DescriptorHeap* GetGlobalSrvUavHeap() const;
+
+	// The device as an integer, for the same reason and by the same route as
+	// GetNativeCommandList: ImGui's DX12 backend needs it at init, and there is no C++ path
+	// off this engine — the only export is PyInit__trinity_dx12.
+	uint64_t GetNativeDevice() const
+	{
+		return static_cast<uint64_t>( reinterpret_cast<uintptr_t>( m_device.p ) );
+	}
+
+	// The heaps Trinity binds, exposed so a hosted UI can put that binding back after it has
+	// drawn. Not heaps the UI draws out of: the host brings its own SRV heap for ImGui's font
+	// descriptor and binds it before drawing, and SetDescriptorHeaps replaces the whole
+	// binding rather than adding to it, so both of Trinity's heaps are unbound by that call
+	// and both have to be restored — see GetNativeSamplerHeap for the other half.
+	uint64_t GetNativeSrvHeap() const
+	{
+		return static_cast<uint64_t>( reinterpret_cast<uintptr_t>( GetGlobalSrvUavHeap() ) );
+	}
+
+	// The direct command queue. ImGui's DX12 backend wants it to upload its font texture at
+	// init; without one that upload has nowhere to go.
+	uint64_t GetNativeCommandQueue() const
+	{
+		return static_cast<uint64_t>( reinterpret_cast<uintptr_t>( m_commandQueue.p ) );
+	}
+
+	// The other half of the restore described above. Easy to leave out, because ImGui itself
+	// never reads it — its root signature declares a static sampler — so the damage lands on
+	// Trinity's own later draws rather than on the UI.
+	uint64_t GetNativeSamplerHeap() const
+	{
+		return static_cast<uint64_t>( reinterpret_cast<uintptr_t>( GetGlobalSamplerHeap() ) );
+	}
 	std::shared_ptr<ShaderResourceViewDx12> GetSrvHeapView() const;
 	std::shared_ptr<UnorderedAccessViewDx12> GetUavHeapView() const;
 	ID3D12DescriptorHeap* GetGlobalSamplerHeap() const;

--- a/trinityal/dx12/Tr2RenderContextDx12.h
+++ b/trinityal/dx12/Tr2RenderContextDx12.h
@@ -275,6 +275,40 @@ public:
 	// extends the interface to support ray tracing and render passes
 	CComPtr<ID3D12GraphicsCommandList4> m_commandList4;
 
+	// Returns this context's native command list as an integer.
+	//
+	// NOT a liveness check. m_commandList is allocated once and reused across frames, so
+	// this is non-zero outside the frame as well — measured identical before, during and
+	// after a pump. Callers must gate on *where* they are (inside a render step) and never
+	// on this value. Zero means only "not a DX12 backend".
+	//
+	// Exists so an immediate-mode UI (ImGui) can record into Trinity's frame from
+	// Python. Trinity ships as a CPython extension module whose only export is
+	// PyInit__trinity_dx12, so a C++ UI layer cannot link against it at all; the
+	// handle has to travel out through Python and back in.
+	//
+	// uint64_t rather than void*, because Blue marshals only the sized integer
+	// types (BlueExposureTypeSignature.h). Declared here on Tr2RenderContextAL
+	// rather than on a Blue class so that both Tr2RenderContext and
+	// Tr2PrimaryRenderContext inherit it, in every backend configuration, with no
+	// per-configuration shim.
+	//
+	// Only meaningful to *record into* while a frame is open, which in practice means from
+	// inside a TriStepPythonCB callback. Nothing here can enforce that.
+	//
+	// Not virtual: backend selection here is by file, not by dispatch — each
+	// backend header declares its own Tr2RenderContextAL and exactly one compiles.
+	uint64_t GetNativeCommandList() const
+	{
+		return static_cast<uint64_t>( reinterpret_cast<uintptr_t>( m_commandList.p ) );
+	}
+
+	// The other four — device, command queue, SRV heap, sampler heap — live on
+	// Tr2PrimaryRenderContextAL rather than here: that is where m_device, m_commandQueue and
+	// the two GetGlobal*Heap accessors are, and at this point in the header
+	// Tr2PrimaryRenderContextAL is only forward-declared, so an inline body could not
+	// dereference m_ownerDevice.
+
 	Tr2PrimaryRenderContextAL* m_ownerDevice;
 	bool m_dirtyPso;
 

--- a/trinityal/include/TrinityALForward.h
+++ b/trinityal/include/TrinityALForward.h
@@ -86,7 +86,6 @@
 #pragma warning( push )
 #pragma warning( disable: 4005 )
 #include <vulkan/vulkan.h>
-#include <vulkan/vk_sdk_platform.h>
 #pragma warning( pop )
 
 #elif TRINITY_PLATFORM == TRINITY_METAL

--- a/trinityal/include/TrinityALForward.h
+++ b/trinityal/include/TrinityALForward.h
@@ -9,6 +9,7 @@
 #define TRINITY_DIRECTX11 2
 #define TRINITY_STUB 5
 #define TRINITY_DIRECTX12 6
+#define TRINITY_VULKAN 7
 #define TRINITY_METAL 10
 
 #ifndef TRINITY_PLATFORM
@@ -45,7 +46,7 @@
 #pragma warning( pop )
 #endif
 
-#if TRINITY_PLATFORM != TRINITY_DIRECTX11 && TRINITY_PLATFORM != TRINITY_DIRECTX12
+#if TRINITY_PLATFORM != TRINITY_DIRECTX11 && TRINITY_PLATFORM != TRINITY_DIRECTX12 && TRINITY_PLATFORM != TRINITY_VULKAN
 #define TRINITY_PLATFORM_HAS_PRIMARY_CONTEXT 0
 #define Tr2PrimaryRenderContextAL Tr2RenderContextAL
 #else
@@ -75,6 +76,18 @@
 
 #include <d3d12.h>
 #include <dxgi1_5.h>
+
+#elif TRINITY_PLATFORM == TRINITY_VULKAN
+
+#define TRINITY_PLATFORM_SYMBOL vulkan
+#define TRINITY_PLATFORM_SYMBOL_SUFFIX Vulkan
+#define TRINITY_PLATFORM_NAME "vulkan"
+
+#pragma warning( push )
+#pragma warning( disable: 4005 )
+#include <vulkan/vulkan.h>
+#include <vulkan/vk_sdk_platform.h>
+#pragma warning( pop )
 
 #elif TRINITY_PLATFORM == TRINITY_METAL
 

--- a/trinityal/metal/Tr2RenderContextMetal.h
+++ b/trinityal/metal/Tr2RenderContextMetal.h
@@ -344,6 +344,35 @@ protected:
 	Tr2UpscalingTechniqueAL* m_upscalingTechnique;
 
 public:
+	// See the DX12 backend for what this is for. There is no DX12 command list
+	// here; Metal's equivalent (MTLRenderCommandEncoder) arrives with M3, and 0 is
+	// the documented "not now" value until then.
+	uint64_t GetNativeCommandList() const
+	{
+		return 0;
+	}
+
+	// See the DX12 backend. No DX12 device or descriptor heap here.
+	uint64_t GetNativeDevice() const
+	{
+		return 0;
+	}
+
+	uint64_t GetNativeSrvHeap() const
+	{
+		return 0;
+	}
+
+	uint64_t GetNativeCommandQueue() const
+	{
+		return 0;
+	}
+
+	uint64_t GetNativeSamplerHeap() const
+	{
+		return 0;
+	}
+
 	void CheckDrawResources();
 
 	MTLIndexType m_metalIndexType;

--- a/trinityal/src/upscaling/Tr2Fsr1Upscaling.cpp
+++ b/trinityal/src/upscaling/Tr2Fsr1Upscaling.cpp
@@ -1,6 +1,6 @@
 // Copyright © 2024 CCP ehf.
 
-#if TRINITY_PLATFORM != TRINITY_STUB
+#if TRINITY_PLATFORM != TRINITY_STUB && TRINITY_PLATFORM != TRINITY_VULKAN
 
 #include "StdAfx.h"
 #include "include/upscaling/Tr2Fsr1Upscaling.h"

--- a/trinityal/stub/Tr2RenderContextStub.h
+++ b/trinityal/stub/Tr2RenderContextStub.h
@@ -290,6 +290,34 @@ private:
 	uint64_t m_frameNumber;
 
 public:
+	// See the DX12 backend for what this is for. There is no DX12 command list
+	// here, and 0 is the documented "not now" value.
+	uint64_t GetNativeCommandList() const
+	{
+		return 0;
+	}
+
+	// See the DX12 backend. No DX12 device or descriptor heap here.
+	uint64_t GetNativeDevice() const
+	{
+		return 0;
+	}
+
+	uint64_t GetNativeSrvHeap() const
+	{
+		return 0;
+	}
+
+	uint64_t GetNativeCommandQueue() const
+	{
+		return 0;
+	}
+
+	uint64_t GetNativeSamplerHeap() const
+	{
+		return 0;
+	}
+
 	TrinityALImpl::Tr2SamplerStateALFactory m_samplerStateFactory;
 };
 

--- a/trinityal/tests/CMakeLists.txt
+++ b/trinityal/tests/CMakeLists.txt
@@ -115,6 +115,25 @@ set(_SHADERS_METAL
     Shaders.metal/WriteToUav.psh
 )
 
+set(_SHADERS_VULKAN
+    Shaders.vulkan/AddConstantToBuffer.csh
+    Shaders.vulkan/AddVectors.csh
+    Shaders.vulkan/ConstantColor.psh
+    Shaders.vulkan/GroupShared.csh
+    Shaders.vulkan/InstancedRendering.vsh
+    Shaders.vulkan/LoadMsaaTexture.psh
+    Shaders.vulkan/OutputTexCoord.psh
+    Shaders.vulkan/OutputVector.csh
+    Shaders.vulkan/PositionOnly.vsh
+    Shaders.vulkan/PositionOnlyWithPerObjectData.vsh
+    Shaders.vulkan/SampleTexture.csh
+    Shaders.vulkan/SampleTextureFromTexCoord.psh
+    Shaders.vulkan/SampleTextureMipFromTexCoord.psh
+    Shaders.vulkan/SampleVolumeTexture.psh
+    Shaders.vulkan/TexCoordAndPosition.vsh
+    Shaders.vulkan/WriteToUav.psh
+)
+
 set(GENERATED_SOURCES_DIR ${CMAKE_CURRENT_BINARY_DIR}/GeneratedSources)
 
 find_package(GTest CONFIG REQUIRED)
@@ -260,6 +279,96 @@ if(WIN32)
         set_target_properties(TrinityALTest_dx12 PROPERTIES FOLDER "Tests")
         #gtest_discover_tests(TrinityALTest_dx12 myListOfTests)
 
+    endif()
+
+    if (BUILD_VULKAN)
+        ccp_add_executable(TrinityALTest_vulkan ${_SOURCES})
+        target_link_libraries(TrinityALTest_vulkan PRIVATE TrinityAL_vulkan)
+        target_compile_definitions(TrinityALTest_vulkan PRIVATE TRINITY_PLATFORM=TRINITY_VULKAN)
+        set_shared_trinityaltest_properties(TrinityALTest_vulkan)
+
+        # Copy DLL dependencies
+        add_custom_command(
+            TARGET TrinityALTest_vulkan POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:TrinityALTest_vulkan> $<TARGET_FILE_DIR:TrinityALTest_vulkan>
+            COMMAND_EXPAND_LISTS
+        )
+
+        target_sources(TrinityALTest_vulkan PRIVATE ${_SHADERS_VULKAN})
+        source_group(Shaders FILES ${_SHADERS_VULKAN})
+
+        # dxc only -- never fxc. fxc cannot emit SPIR-V, and it is fetched from the
+        # internal host vcpkg-prebuilt-sdks.ccpgames.com, which would tie the one
+        # Windows configuration that builds outside the CCP network to that host (R6).
+        #
+        # directx-dxc-config.cmake sets DIRECTX_DXC_TOOL itself, as a CACHE PATH
+        # pointing at tools/directx-dxc/dxc.exe relative to the package root, so
+        # find_package is the whole resolution -- no find_program, and no path into
+        # the binary dir written down here. (Its two imported targets,
+        # Microsoft::DirectXShaderCompiler and Microsoft::DXIL, are the dxcompiler.dll
+        # library, not the driver executable, so $<TARGET_FILE:...> is not what we
+        # want.) The dx12 block above only assigns DIRECTX_DXC_TOOL by hand on the
+        # BUILD_FOR_PYTHON_2 path, where the port is the older `dxc` package that
+        # does not set it.
+        find_package(directx-dxc CONFIG REQUIRED)
+
+        # Reproduces Tr2ShaderProgramALVulkan.cpp's binding formula from the shader
+        # side: binding = registerIndex + classOffset * 6 * 32 + shaderType * 32,
+        # with classOffset b=0, s=2, t=1, u=0 (RegisterClassOffset) and shaderType
+        # from Tr2RenderContextEnum::ShaderType (VERTEX=0, PIXEL=1, COMPUTE=2).
+        # Constant buffers stay in space0 -> descriptor set 0 (m_constantLayout);
+        # t/s/u are declared space1 in the sources -> set 1 (m_resourceLayout).
+        # These two sides are one ABI. Change neither alone.
+        set(_VK_REGISTER_SIZE 32)
+        set(_VK_CLASS_BLOCK 192)   # 6 * _VK_REGISTER_SIZE
+
+        # Matches the instance the backend actually creates: VkApplicationInfo's
+        # apiVersion is VK_MAKE_VERSION(1,0,0) at
+        # trinityal/vulkan/Tr2VideoAdapterInfoALVulkan.cpp:129 (the whole struct is
+        # 1.0), and nothing under trinityal/vulkan requests more. A SPIR-V module
+        # built for a newer environment than the instance requests is a validation
+        # error, so this tracks that line and is not a free choice. Phase 3 raises
+        # both together, with dynamic_rendering and synchronization2.
+        set(_VK_TARGET_ENV vulkan1.0)
+
+        foreach(shaderSource ${_SHADERS_VULKAN})
+            string(REGEX REPLACE "h$" ".h" shaderOutput ${shaderSource})
+            if(${shaderSource} MATCHES ".*psh$")
+                set(SHADER_TARGET "ps_6_0")
+                set(_VK_STAGE 1)
+            elseif(${shaderSource} MATCHES ".*vsh$")
+                set(SHADER_TARGET "vs_6_0")
+                set(_VK_STAGE 0)
+            else()
+                set(SHADER_TARGET "cs_6_0")
+                set(_VK_STAGE 2)
+            endif()
+
+            math(EXPR _VK_STAGE_BASE "${_VK_STAGE} * ${_VK_REGISTER_SIZE}")
+            math(EXPR _VK_B_SHIFT "0 * ${_VK_CLASS_BLOCK} + ${_VK_STAGE_BASE}")
+            math(EXPR _VK_T_SHIFT "1 * ${_VK_CLASS_BLOCK} + ${_VK_STAGE_BASE}")
+            math(EXPR _VK_S_SHIFT "2 * ${_VK_CLASS_BLOCK} + ${_VK_STAGE_BASE}")
+            math(EXPR _VK_U_SHIFT "0 * ${_VK_CLASS_BLOCK} + ${_VK_STAGE_BASE}")
+
+            add_custom_command(
+                OUTPUT ${GENERATED_SOURCES_DIR}/${shaderOutput}
+                COMMAND ${CMAKE_COMMAND} -E make_directory ${GENERATED_SOURCES_DIR}/Shaders.vulkan
+                COMMAND ${DIRECTX_DXC_TOOL} -nologo -spirv -T ${SHADER_TARGET} -E main
+                        -fspv-target-env=${_VK_TARGET_ENV}
+                        -fvk-b-shift ${_VK_B_SHIFT} 0
+                        -fvk-t-shift ${_VK_T_SHIFT} 1
+                        -fvk-s-shift ${_VK_S_SHIFT} 1
+                        -fvk-u-shift ${_VK_U_SHIFT} 1
+                        -Fo ${GENERATED_SOURCES_DIR}/${shaderSource}.bin ${CMAKE_CURRENT_SOURCE_DIR}/${shaderSource}
+                COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/bin2h.cmd ${GENERATED_SOURCES_DIR}/${shaderSource}.bin ${GENERATED_SOURCES_DIR}/${shaderOutput}
+                MAIN_DEPENDENCY ${shaderSource}
+            )
+        endforeach()
+
+        set_target_properties(TrinityALTest_vulkan PROPERTIES FOLDER "Tests")
+
+        enable_testing()
+        add_test(NAME TrinityALTest_vulkan COMMAND TrinityALTest_vulkan)
     endif()
 
 endif()

--- a/trinityal/tests/CMakeLists.txt
+++ b/trinityal/tests/CMakeLists.txt
@@ -28,6 +28,11 @@ set(_SOURCES
     Rendering.cpp
     SamplerState.cpp
     Shader.cpp
+    # Vulkan-only in its entirety (guarded by TRINITY_PLATFORM == TRINITY_VULKAN), but
+    # listed here because every backend target compiles this one _SOURCES list. It
+    # asserts the descriptor set/binding ABI by walking the shipped SPIR-V modules; no
+    # GPU and no device involved.
+    ShaderBindingABI.cpp
     StdAfx.h
     StdAfx.cpp
     SwapChain.cpp

--- a/trinityal/tests/ShaderBindingABI.cpp
+++ b/trinityal/tests/ShaderBindingABI.cpp
@@ -1,0 +1,415 @@
+// Copyright © 2026 CCP ehf.
+
+#include "StdAfx.h"
+
+// The whole file is Vulkan-only. dx11, dx12 and metal compile the same `_SOURCES`
+// list, and neither the SPIR-V modules nor the binding formula this asserts exist on
+// those backends.
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "vulkan/Tr2ShaderBindingABIVulkan.h"
+
+#include <algorithm>
+#include <cstring>
+#include <map>
+#include <sstream>
+#include <vector>
+
+// Asserts the Vulkan binding ABI, statically, with no GPU and no VkDevice.
+//
+// Three artifacts have to agree on every descriptor set and binding number, in three
+// languages, and until this file existed nothing produced a diagnostic when they
+// drifted:
+//
+//   1. Tr2ShaderProgramALVulkan.cpp's binding formula (now
+//      Tr2ShaderBindingABIVulkan.h), which builds the VkDescriptorSetLayoutBindings.
+//   2. trinityal/tests/CMakeLists.txt's -fvk-{b,t,s,u}-shift arithmetic, which tells
+//      dxc what to bake into the SPIR-V.
+//   3. the Shaders.vulkan/*.{vsh,psh,csh} sources' own register declarations,
+//      including the `space` that becomes the descriptor set.
+//
+// All three of this branch's ABI defects were that same failure: Phase 1's Tasks 4e
+// and 4f moved every SRV/UAV binding as a side effect of a descriptor-*type* fix, and
+// SampleTextureMipFromTexCoord.psh's DX9-style `register( ps, c0 )` folded its
+// constant buffer into an implicit `$Globals` that dxc assigns binding 0 *without*
+// applying -fvk-b-shift -- so the module read set 0 / binding 0 while the layout
+// declared 32. Phase 2a's spot-check of five decorations missed it structurally: of the
+// two constant buffers it sampled, one was `b1` compute and the other `b0` *vertex*,
+// and at the vertex stage the shift is 0 * 32 = 0, so that case cannot distinguish
+// "shift applied" from "shift ignored". The single discriminating case -- a `b0` at a
+// non-vertex stage -- was the one never sampled.
+//
+// Every Shaders.vulkan/*.h generated header is a complete SPIR-V module already
+// compiled into this binary, so the check is pure bytecode inspection: walk each
+// module's OpDecorate stream for DescriptorSet and Binding, and compare what dxc
+// actually emitted against what the AL's own formula computes for that shader's
+// declared registers.
+//
+// The expected values are *derived, not tabulated*: EXPECTED_* below lists only what
+// the HLSL source declares -- register class, index, stage -- and every number under
+// test comes out of Tr2VulkanBindingABI::BindingNumber / DescriptorSetIndex, the same
+// functions Tr2ShaderProgramALVulkan.cpp calls. A hardcoded table of sixteen expected
+// binding numbers would keep passing while the formula drifted, which is exactly the
+// failure mode this file exists to close. (RegisterClassOffset used to sit in an
+// anonymous namespace in Tr2ShaderProgramALVulkan.cpp and was unreachable from here;
+// it was lifted into Tr2ShaderBindingABIVulkan.h rather than copied, so there is still
+// one source of truth.)
+
+using namespace Tr2RenderContextEnum;
+
+namespace
+{
+
+// ---------------------------------------------------------------------------
+// The sixteen modules, as bytes.
+// ---------------------------------------------------------------------------
+
+const uint8_t g_addConstantToBufferCs[] = {
+#include INCLUDE_SHADER_CODE( AddConstantToBuffer.cs )
+};
+const uint8_t g_addVectorsCs[] = {
+#include INCLUDE_SHADER_CODE( AddVectors.cs )
+};
+const uint8_t g_constantColorPs[] = {
+#include INCLUDE_SHADER_CODE( ConstantColor.ps )
+};
+const uint8_t g_groupSharedCs[] = {
+#include INCLUDE_SHADER_CODE( GroupShared.cs )
+};
+const uint8_t g_instancedRenderingVs[] = {
+#include INCLUDE_SHADER_CODE( InstancedRendering.vs )
+};
+const uint8_t g_loadMsaaTexturePs[] = {
+#include INCLUDE_SHADER_CODE( LoadMsaaTexture.ps )
+};
+const uint8_t g_outputTexCoordPs[] = {
+#include INCLUDE_SHADER_CODE( OutputTexCoord.ps )
+};
+const uint8_t g_outputVectorCs[] = {
+#include INCLUDE_SHADER_CODE( OutputVector.cs )
+};
+const uint8_t g_positionOnlyVs[] = {
+#include INCLUDE_SHADER_CODE( PositionOnly.vs )
+};
+const uint8_t g_positionOnlyWithPerObjectDataVs[] = {
+#include INCLUDE_SHADER_CODE( PositionOnlyWithPerObjectData.vs )
+};
+const uint8_t g_sampleTextureCs[] = {
+#include INCLUDE_SHADER_CODE( SampleTexture.cs )
+};
+const uint8_t g_sampleTextureFromTexCoordPs[] = {
+#include INCLUDE_SHADER_CODE( SampleTextureFromTexCoord.ps )
+};
+const uint8_t g_sampleTextureMipFromTexCoordPs[] = {
+#include INCLUDE_SHADER_CODE( SampleTextureMipFromTexCoord.ps )
+};
+const uint8_t g_sampleVolumeTexturePs[] = {
+#include INCLUDE_SHADER_CODE( SampleVolumeTexture.ps )
+};
+const uint8_t g_texCoordAndPositionVs[] = {
+#include INCLUDE_SHADER_CODE( TexCoordAndPosition.vs )
+};
+const uint8_t g_writeToUavPs[] = {
+#include INCLUDE_SHADER_CODE( WriteToUav.ps )
+};
+
+// ---------------------------------------------------------------------------
+// What each source declares. Inputs to the formula, never its outputs.
+// ---------------------------------------------------------------------------
+
+struct DeclaredRegister
+{
+	Tr2ShaderRegisterAL::RegisterType registerType;
+	uint32_t registerIndex;
+};
+
+struct ShaderModule
+{
+	const char* name;
+	const uint8_t* bytecode;
+	size_t byteCount;
+	ShaderType stage;
+	const DeclaredRegister* registers;
+	size_t registerCount;
+};
+
+// One entry per HLSL declaration in the corresponding Shaders.vulkan source. The
+// RegisterType subtype (SRV_BUFFER vs SRV_TEXTURE2D, ...) is spelled as the source
+// declares it and as the tests' own Tr2ShaderSignatureAL calls spell it, so that a
+// future descriptor-kind change that wrongly leaks into the binding blocks is caught.
+const DeclaredRegister EXPECTED_ADD_CONSTANT_TO_BUFFER[] = {
+	{ Tr2ShaderRegisterAL::CONSTANT_BUFFER, 1 },   // cbuffer Constants : register(b1)
+	{ Tr2ShaderRegisterAL::SRV_BUFFER, 0 },        // Buffer<float4>   arg2   : t0, space1
+	{ Tr2ShaderRegisterAL::UAV_BUFFER, 0 },        // RWBuffer<float4> output : u0, space1
+};
+const DeclaredRegister EXPECTED_ADD_VECTORS[] = {
+	{ Tr2ShaderRegisterAL::SRV_BUFFER, 0 },
+	{ Tr2ShaderRegisterAL::SRV_BUFFER, 1 },
+	{ Tr2ShaderRegisterAL::UAV_BUFFER, 0 },
+};
+const DeclaredRegister EXPECTED_GROUP_SHARED[] = {
+	{ Tr2ShaderRegisterAL::UAV_BUFFER, 0 },
+};
+const DeclaredRegister EXPECTED_LOAD_MSAA_TEXTURE[] = {
+	{ Tr2ShaderRegisterAL::SRV_TEXTURE2DMS, 0 },
+};
+const DeclaredRegister EXPECTED_OUTPUT_VECTOR[] = {
+	{ Tr2ShaderRegisterAL::UAV_BUFFER, 0 },
+};
+const DeclaredRegister EXPECTED_POSITION_ONLY_WITH_PER_OBJECT_DATA[] = {
+	{ Tr2ShaderRegisterAL::CONSTANT_BUFFER, 0 },
+};
+const DeclaredRegister EXPECTED_SAMPLE_TEXTURE[] = {
+	{ Tr2ShaderRegisterAL::SRV_TEXTURE2D, 0 },
+	{ Tr2ShaderRegisterAL::SAMPLER, 0 },
+	{ Tr2ShaderRegisterAL::UAV_BUFFER, 0 },
+};
+const DeclaredRegister EXPECTED_SAMPLE_TEXTURE_FROM_TEXCOORD[] = {
+	{ Tr2ShaderRegisterAL::SRV_TEXTURE2D, 0 },
+	{ Tr2ShaderRegisterAL::SAMPLER, 0 },
+};
+// The Fix 1 shader. `b0` at the *pixel* stage is the one case in the whole set that
+// distinguishes "-fvk-b-shift applied" from "-fvk-b-shift ignored", because every
+// other set-0 register here is either `b1` (which is non-zero either way) or vertex
+// stage (where the shift is 0 * 32 = 0). Before Fix 1 this module decorated
+// set 0 / binding 0 and this entry expected 32.
+const DeclaredRegister EXPECTED_SAMPLE_TEXTURE_MIP_FROM_TEXCOORD[] = {
+	{ Tr2ShaderRegisterAL::CONSTANT_BUFFER, 0 },
+	{ Tr2ShaderRegisterAL::SRV_TEXTURE2D, 0 },
+	{ Tr2ShaderRegisterAL::SAMPLER, 0 },
+};
+const DeclaredRegister EXPECTED_SAMPLE_VOLUME_TEXTURE[] = {
+	{ Tr2ShaderRegisterAL::CONSTANT_BUFFER, 0 },
+	{ Tr2ShaderRegisterAL::SRV_TEXTURE3D, 0 },
+	{ Tr2ShaderRegisterAL::SAMPLER, 0 },
+};
+const DeclaredRegister EXPECTED_WRITE_TO_UAV[] = {
+	{ Tr2ShaderRegisterAL::UAV_TEXTURE2D, 1 },
+};
+
+#define SHADER_MODULE( bytes, stage, expected ) \
+	{ #bytes, bytes, sizeof( bytes ), stage, expected, sizeof( expected ) / sizeof( expected[0] ) }
+#define SHADER_MODULE_NO_REGISTERS( bytes, stage ) \
+	{ #bytes, bytes, sizeof( bytes ), stage, nullptr, 0 }
+
+const ShaderModule ALL_MODULES[] = {
+	SHADER_MODULE( g_addConstantToBufferCs, COMPUTE_SHADER, EXPECTED_ADD_CONSTANT_TO_BUFFER ),
+	SHADER_MODULE( g_addVectorsCs, COMPUTE_SHADER, EXPECTED_ADD_VECTORS ),
+	SHADER_MODULE_NO_REGISTERS( g_constantColorPs, PIXEL_SHADER ),
+	SHADER_MODULE( g_groupSharedCs, COMPUTE_SHADER, EXPECTED_GROUP_SHARED ),
+	SHADER_MODULE_NO_REGISTERS( g_instancedRenderingVs, VERTEX_SHADER ),
+	SHADER_MODULE( g_loadMsaaTexturePs, PIXEL_SHADER, EXPECTED_LOAD_MSAA_TEXTURE ),
+	SHADER_MODULE_NO_REGISTERS( g_outputTexCoordPs, PIXEL_SHADER ),
+	SHADER_MODULE( g_outputVectorCs, COMPUTE_SHADER, EXPECTED_OUTPUT_VECTOR ),
+	SHADER_MODULE_NO_REGISTERS( g_positionOnlyVs, VERTEX_SHADER ),
+	SHADER_MODULE( g_positionOnlyWithPerObjectDataVs, VERTEX_SHADER, EXPECTED_POSITION_ONLY_WITH_PER_OBJECT_DATA ),
+	SHADER_MODULE( g_sampleTextureCs, COMPUTE_SHADER, EXPECTED_SAMPLE_TEXTURE ),
+	SHADER_MODULE( g_sampleTextureFromTexCoordPs, PIXEL_SHADER, EXPECTED_SAMPLE_TEXTURE_FROM_TEXCOORD ),
+	SHADER_MODULE( g_sampleTextureMipFromTexCoordPs, PIXEL_SHADER, EXPECTED_SAMPLE_TEXTURE_MIP_FROM_TEXCOORD ),
+	SHADER_MODULE( g_sampleVolumeTexturePs, PIXEL_SHADER, EXPECTED_SAMPLE_VOLUME_TEXTURE ),
+	SHADER_MODULE_NO_REGISTERS( g_texCoordAndPositionVs, VERTEX_SHADER ),
+	SHADER_MODULE( g_writeToUavPs, PIXEL_SHADER, EXPECTED_WRITE_TO_UAV ),
+};
+
+const size_t MODULE_COUNT = sizeof( ALL_MODULES ) / sizeof( ALL_MODULES[0] );
+
+// ---------------------------------------------------------------------------
+// A minimal SPIR-V decoration reader.
+// ---------------------------------------------------------------------------
+//
+// SPIR-V is a stream of 32-bit words: a five-word header, then instructions whose
+// first word packs the opcode in the low 16 bits and the instruction's total word
+// count in the high 16. Walking by that word count -- rather than assuming any
+// particular instruction order or that decorations are contiguous -- is the whole
+// parser.
+
+const uint32_t SPIRV_MAGIC = 0x07230203u;
+const size_t SPIRV_HEADER_WORDS = 5;
+const uint32_t OP_DECORATE = 71;
+const uint32_t DECORATION_BINDING = 33;
+const uint32_t DECORATION_DESCRIPTOR_SET = 34;
+
+struct SpirvBinding
+{
+	uint32_t set;
+	uint32_t binding;
+};
+
+bool operator<( const SpirvBinding& a, const SpirvBinding& b )
+{
+	return a.set != b.set ? a.set < b.set : a.binding < b.binding;
+}
+
+bool operator==( const SpirvBinding& a, const SpirvBinding& b )
+{
+	return a.set == b.set && a.binding == b.binding;
+}
+
+// gtest finds this by ADL and uses it instead of dumping the raw object bytes, so a
+// failure reads "set 0/binding 32" rather than "8-byte object <00-00 ...>".
+std::ostream& operator<<( std::ostream& out, const SpirvBinding& b )
+{
+	return out << "set " << b.set << "/binding " << b.binding;
+}
+
+std::string Describe( const std::vector<SpirvBinding>& bindings )
+{
+	std::ostringstream out;
+	out << "{ ";
+	for( size_t i = 0; i < bindings.size(); ++i )
+	{
+		out << ( i ? ", " : "" ) << "set " << bindings[i].set << "/binding " << bindings[i].binding;
+	}
+	out << ( bindings.empty() ? "(none) }" : " }" );
+	return out.str();
+}
+
+// Reads every id that carries both a DescriptorSet and a Binding decoration.
+// Returns an assertion result so that a malformed module reports as a parser failure
+// rather than as an empty -- and therefore possibly passing -- binding list.
+::testing::AssertionResult ReadDecoratedBindings( const uint8_t* bytes, size_t byteCount, std::vector<SpirvBinding>& out )
+{
+	out.clear();
+
+	if( byteCount < SPIRV_HEADER_WORDS * sizeof( uint32_t ) || byteCount % sizeof( uint32_t ) != 0 )
+	{
+		return ::testing::AssertionFailure() << "not a SPIR-V module: " << byteCount << " bytes";
+	}
+
+	// memcpy rather than a reinterpret_cast: a uint8_t[] has no alignment guarantee.
+	std::vector<uint32_t> words( byteCount / sizeof( uint32_t ) );
+	memcpy( words.data(), bytes, byteCount );
+
+	if( words[0] != SPIRV_MAGIC )
+	{
+		std::ostringstream magic;
+		magic << std::hex << words[0];
+		return ::testing::AssertionFailure()
+			<< "bad SPIR-V magic 0x" << magic.str()
+			<< " (expected 0x07230203; a byte-swapped 0x03022307 would mean the module "
+			<< "was produced for the opposite endianness, which this walker does not handle)";
+	}
+
+	// id -> (set, binding), each present only once decorated.
+	std::map<uint32_t, std::pair<bool, uint32_t> > sets, bindings;
+
+	for( size_t i = SPIRV_HEADER_WORDS; i < words.size(); )
+	{
+		const uint32_t opcode = words[i] & 0xFFFFu;
+		const uint32_t wordCount = words[i] >> 16;
+
+		if( wordCount == 0 || i + wordCount > words.size() )
+		{
+			return ::testing::AssertionFailure()
+				<< "malformed SPIR-V at word " << i << ": opcode " << opcode
+				<< ", wordCount " << wordCount << ", " << words.size() << " words total";
+		}
+
+		if( opcode == OP_DECORATE && wordCount >= 4 )
+		{
+			const uint32_t target = words[i + 1];
+			const uint32_t decoration = words[i + 2];
+			const uint32_t value = words[i + 3];
+
+			if( decoration == DECORATION_DESCRIPTOR_SET )
+			{
+				sets[target] = std::make_pair( true, value );
+			}
+			else if( decoration == DECORATION_BINDING )
+			{
+				bindings[target] = std::make_pair( true, value );
+			}
+		}
+
+		i += wordCount;
+	}
+
+	for( auto it = bindings.begin(); it != bindings.end(); ++it )
+	{
+		auto setIt = sets.find( it->first );
+		if( setIt == sets.end() )
+		{
+			return ::testing::AssertionFailure()
+				<< "id " << it->first << " has a Binding decoration but no DescriptorSet decoration";
+		}
+		SpirvBinding b = { setIt->second.second, it->second.second };
+		out.push_back( b );
+	}
+	for( auto it = sets.begin(); it != sets.end(); ++it )
+	{
+		if( bindings.find( it->first ) == bindings.end() )
+		{
+			return ::testing::AssertionFailure()
+				<< "id " << it->first << " has a DescriptorSet decoration but no Binding decoration";
+		}
+	}
+
+	std::sort( out.begin(), out.end() );
+	return ::testing::AssertionSuccess();
+}
+
+}
+
+// The main assertion. For each of the sixteen shipped SPIR-V modules, the multiset of
+// (DescriptorSet, Binding) pairs dxc emitted must equal the multiset the AL's own
+// formula computes from that shader's declared registers.
+TEST( ShaderBindingABI, EverySpirvModuleDecoratesWhatTheALBindingFormulaComputes )
+{
+	ASSERT_EQ( size_t( 16 ), MODULE_COUNT )
+		<< "Shaders.vulkan has sixteen sources; a shader added or removed without "
+		<< "updating ALL_MODULES leaves the new one unchecked";
+
+	for( size_t m = 0; m < MODULE_COUNT; ++m )
+	{
+		// The failing module is named in every message below rather than via
+		// SCOPED_TRACE: SCOPED_TRACE here access-violates (0xC0000005) on destruction in
+		// this build of the suite -- no other test in TrinityALTest uses it, so it has
+		// never been exercised on any backend. Not investigated: out of scope for this
+		// fix wave, and reported rather than worked around silently.
+		const ShaderModule& module = ALL_MODULES[m];
+
+		std::vector<SpirvBinding> actual;
+		ASSERT_TRUE( ReadDecoratedBindings( module.bytecode, module.byteCount, actual ) )
+			<< "while reading " << module.name;
+
+		std::vector<SpirvBinding> expected;
+		for( size_t r = 0; r < module.registerCount; ++r )
+		{
+			const DeclaredRegister& declared = module.registers[r];
+			SpirvBinding b = {
+				Tr2VulkanBindingABI::DescriptorSetIndex( declared.registerType ),
+				Tr2VulkanBindingABI::BindingNumber( declared.registerType, declared.registerIndex, module.stage )
+			};
+			expected.push_back( b );
+		}
+		std::sort( expected.begin(), expected.end() );
+
+		EXPECT_EQ( expected, actual )
+			<< module.name << ": the AL formula gives " << Describe( expected )
+			<< ", the SPIR-V module decorates " << Describe( actual );
+	}
+}
+
+// Guards the walker itself, so that the assertion above cannot pass vacuously because
+// the reader silently found nothing. The stream below places an OpDecorate after a
+// longer instruction and interleaves an unrelated decoration, so only a reader that
+// advances by wordCount and filters on the decoration operand lands on it.
+TEST( ShaderBindingABI, TheDecorationWalkerFindsDecorationsItIsNotHandedInOrder )
+{
+	const uint32_t words[] = {
+		SPIRV_MAGIC, 0x00010000u, 0u, 1u, 0u,             // 5-word header
+		( 5u << 16 ) | 11u,   9u, 1u, 2u, 3u,             // some 5-word instruction, not OpDecorate
+		( 4u << 16 ) | OP_DECORATE, 7u, 0u, 0u,           // OpDecorate %7 RelaxedPrecision-ish: ignored
+		( 4u << 16 ) | OP_DECORATE, 7u, DECORATION_BINDING, 224u,
+		( 3u << 16 ) | 5u,    7u, 0u,                     // a 3-word instruction in between
+		( 4u << 16 ) | OP_DECORATE, 7u, DECORATION_DESCRIPTOR_SET, 1u,
+	};
+
+	std::vector<SpirvBinding> actual;
+	ASSERT_TRUE( ReadDecoratedBindings( reinterpret_cast<const uint8_t*>( words ), sizeof( words ), actual ) );
+	ASSERT_EQ( size_t( 1 ), actual.size() );
+	EXPECT_EQ( 1u, actual[0].set );
+	EXPECT_EQ( 224u, actual[0].binding );
+}
+
+#endif

--- a/trinityal/tests/Shaders.vulkan/AddConstantToBuffer.csh
+++ b/trinityal/tests/Shaders.vulkan/AddConstantToBuffer.csh
@@ -1,0 +1,17 @@
+// Copyright © 2023 CCP ehf.
+
+cbuffer Constants: register(b1)
+{
+    float4 arg1;
+};
+
+Buffer<float4> arg2: register(t0, space1);
+
+
+RWBuffer<float4> output: register(u0, space1);
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    output[0] = arg1 + arg2[0];
+}

--- a/trinityal/tests/Shaders.vulkan/AddVectors.csh
+++ b/trinityal/tests/Shaders.vulkan/AddVectors.csh
@@ -1,0 +1,13 @@
+// Copyright © 2023 CCP ehf.
+
+Buffer<float4> arg1: register(t0, space1);
+Buffer<float4> arg2: register(t1, space1);
+
+
+RWBuffer<float4> output: register(u0, space1);
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    output[0] = arg1[0] + arg2[0];
+}

--- a/trinityal/tests/Shaders.vulkan/ConstantColor.psh
+++ b/trinityal/tests/Shaders.vulkan/ConstantColor.psh
@@ -1,0 +1,12 @@
+// Copyright © 2023 CCP ehf.
+
+struct VS_OUTPUT
+{
+	float4 Position : SV_Position;
+};
+
+float4 main(VS_OUTPUT In) : SV_Target
+{
+    float4 color = float4( 1, 0, 0, 1 );
+    return color;
+}

--- a/trinityal/tests/Shaders.vulkan/GroupShared.csh
+++ b/trinityal/tests/Shaders.vulkan/GroupShared.csh
@@ -1,0 +1,24 @@
+// Copyright © 2023 CCP ehf.
+
+RWBuffer<uint> output: register(u0, space1);
+
+
+groupshared uint sum;
+
+[numthreads(10, 10, 2)]
+void main(uint3 globalIdx : SV_DispatchThreadID)
+{
+    if( all( globalIdx == 0 ) )
+    {
+        sum = 0;
+    }
+    GroupMemoryBarrierWithGroupSync();
+    
+    InterlockedAdd( sum, globalIdx.x + globalIdx.y + globalIdx.z );
+
+    GroupMemoryBarrierWithGroupSync();
+    if( all( globalIdx == 0 ) )
+    {
+        output[0] = sum;
+    }
+}

--- a/trinityal/tests/Shaders.vulkan/InstancedRendering.vsh
+++ b/trinityal/tests/Shaders.vulkan/InstancedRendering.vsh
@@ -1,0 +1,19 @@
+// Copyright © 2023 CCP ehf.
+
+struct VS_OUTPUT
+{
+	float4 Position : SV_Position;
+};
+
+struct VS_INPUT
+{
+    float3 Position : POSITION;
+    float2 Offset : POSITION8;
+};
+
+VS_OUTPUT main( VS_INPUT input )
+{
+	VS_OUTPUT Output;
+	Output.Position = float4(input.Position + float3(input.Offset, 0), 1);
+	return Output;    
+}

--- a/trinityal/tests/Shaders.vulkan/LoadMsaaTexture.psh
+++ b/trinityal/tests/Shaders.vulkan/LoadMsaaTexture.psh
@@ -1,0 +1,17 @@
+// Copyright © 2023 CCP ehf.
+
+struct VS_OUTPUT
+{
+	float4 Position : SV_Position;
+	float2 TexCoord : TEXCOORD;
+};
+
+Texture2DMS<float4> tex0: register( t0, space1 );
+
+float4 main(VS_OUTPUT In) : SV_Target
+{
+    uint w, h, s;
+    tex0.GetDimensions( w, h, s );
+    float4 color = tex0.Load( int2( In.TexCoord * float2( w, h ) ), 0 );
+    return color;
+}

--- a/trinityal/tests/Shaders.vulkan/OutputTexCoord.psh
+++ b/trinityal/tests/Shaders.vulkan/OutputTexCoord.psh
@@ -1,0 +1,13 @@
+// Copyright © 2023 CCP ehf.
+
+struct VS_OUTPUT
+{
+	float4 Position : SV_Position;
+	float2 TexCoord : TEXCOORD;
+};
+
+float4 main(VS_OUTPUT In) : SV_Target
+{
+    float4 color = float4( In.TexCoord, 0, 1 );
+    return color;
+}

--- a/trinityal/tests/Shaders.vulkan/OutputVector.csh
+++ b/trinityal/tests/Shaders.vulkan/OutputVector.csh
@@ -1,0 +1,9 @@
+// Copyright © 2023 CCP ehf.
+
+RWBuffer<float4> output: register(u0, space1);
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    output[0] = float4( 1, 2, 3, 4 );
+}

--- a/trinityal/tests/Shaders.vulkan/PositionOnly.vsh
+++ b/trinityal/tests/Shaders.vulkan/PositionOnly.vsh
@@ -1,0 +1,18 @@
+// Copyright © 2023 CCP ehf.
+
+struct VS_OUTPUT
+{
+	float4 Position : SV_Position;
+};
+
+struct VS_INPUT
+{
+    float3 Position : POSITION;
+};
+
+VS_OUTPUT main( VS_INPUT input )
+{
+	VS_OUTPUT Output;
+	Output.Position = float4(input.Position, 1);
+	return Output;    
+}

--- a/trinityal/tests/Shaders.vulkan/PositionOnlyWithPerObjectData.vsh
+++ b/trinityal/tests/Shaders.vulkan/PositionOnlyWithPerObjectData.vsh
@@ -1,0 +1,26 @@
+// Copyright © 2023 CCP ehf.
+
+struct VS_OUTPUT
+{
+	float4 Position : SV_Position;
+};
+
+struct VS_INPUT
+{
+    float3 Position : POSITION;
+};
+
+cbuffer cb0: register(b0)
+{
+    struct PerObjectVSData
+    {
+        float2 position;
+    } PerObjectVS;
+}
+
+VS_OUTPUT main( VS_INPUT input )
+{
+	VS_OUTPUT Output;
+	Output.Position = float4(input.Position + float3( PerObjectVS.position, 0 ), 1);
+	return Output;    
+}

--- a/trinityal/tests/Shaders.vulkan/SampleTexture.csh
+++ b/trinityal/tests/Shaders.vulkan/SampleTexture.csh
@@ -1,0 +1,13 @@
+// Copyright © 2023 CCP ehf.
+
+Texture2D<float> tex: register(t0, space1);
+SamplerState sampl: register(s0, space1);
+RWBuffer<float4> output: register(u0, space1);
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    float avg = tex[uint2(0, 0)] + tex[uint2(1, 0)] + tex[uint2(0, 1)] + tex[uint2(1, 1)];
+    float sampled = tex.SampleLevel( sampl, float2( 0.5, 0.5 ), 0.0 ).x;
+    output[0] = float4( avg, sampled, 0, 0 );
+}

--- a/trinityal/tests/Shaders.vulkan/SampleTextureFromTexCoord.psh
+++ b/trinityal/tests/Shaders.vulkan/SampleTextureFromTexCoord.psh
@@ -1,0 +1,16 @@
+// Copyright © 2023 CCP ehf.
+
+struct VS_OUTPUT
+{
+	float4 Position : SV_Position;
+	float2 TexCoord : TEXCOORD;
+};
+
+Texture2D tex0: register( t0, space1 );
+SamplerState sampl: register( s0, space1 );
+
+float4 main(VS_OUTPUT In) : SV_Target
+{
+    float4 color = tex0.Sample( sampl, In.TexCoord );
+    return color;
+}

--- a/trinityal/tests/Shaders.vulkan/SampleTextureMipFromTexCoord.psh
+++ b/trinityal/tests/Shaders.vulkan/SampleTextureMipFromTexCoord.psh
@@ -6,10 +6,22 @@ struct VS_OUTPUT
 	float2 TexCoord : TEXCOORD;
 };
 
-struct PerObjectPSData
+// The DX11 copy of this shader declares this as `struct ... PerObjectPS: register(
+// ps, c0 )`, a DX9-style annotation that dxc -spirv ignores: it folds the global into
+// an implicit `$Globals` cbuffer and assigns that binding 0 *without* applying
+// -fvk-b-shift, so the module read set 0 / binding 0 while the AL's formula declared
+// a binding at 0 + 0*192 + 1*32 = 32 -- a pipeline-layout/shader incompatibility.
+// Spelled as an explicit cbuffer at register(b0) here, matching the other fifteen
+// Shaders.vulkan sources, so the shift applies. Struct name, member name and the
+// resulting constant-buffer layout (one float at offset 0) are unchanged, so this
+// stays behaviourally identical to the DX11 copy.
+cbuffer cb0: register(b0)
 {
-    float lod;
-} PerObjectPS: register( ps, c0 );
+    struct PerObjectPSData
+    {
+        float lod;
+    } PerObjectPS;
+}
 
 Texture2D tex0: register( t0, space1 );
 SamplerState sampl: register( s0, space1 );

--- a/trinityal/tests/Shaders.vulkan/SampleTextureMipFromTexCoord.psh
+++ b/trinityal/tests/Shaders.vulkan/SampleTextureMipFromTexCoord.psh
@@ -1,0 +1,21 @@
+// Copyright © 2023 CCP ehf.
+
+struct VS_OUTPUT
+{
+	float4 Position : SV_Position;
+	float2 TexCoord : TEXCOORD;
+};
+
+struct PerObjectPSData
+{
+    float lod;
+} PerObjectPS: register( ps, c0 );
+
+Texture2D tex0: register( t0, space1 );
+SamplerState sampl: register( s0, space1 );
+
+float4 main(VS_OUTPUT In) : SV_Target
+{
+    float4 color = tex0.SampleLevel( sampl, In.TexCoord, PerObjectPS.lod );
+    return color;
+}

--- a/trinityal/tests/Shaders.vulkan/SampleVolumeTexture.psh
+++ b/trinityal/tests/Shaders.vulkan/SampleVolumeTexture.psh
@@ -1,0 +1,25 @@
+// Copyright © 2023 CCP ehf.
+
+struct VS_OUTPUT
+{
+	float4 Position : SV_Position;
+	float2 TexCoord : TEXCOORD;
+};
+
+Texture3D tex0: register( t0, space1 );
+SamplerState sampl: register( s0, space1 );
+
+
+cbuffer cb0: register(b0)
+{
+    struct PerObjectVSData
+    {
+        float layer;
+    } PerObjectVS;
+}
+
+float4 main(VS_OUTPUT In) : SV_Target
+{
+    float4 color = tex0.Sample( sampl, float3( In.TexCoord, PerObjectVS.layer ) );
+    return color;
+}

--- a/trinityal/tests/Shaders.vulkan/TexCoordAndPosition.vsh
+++ b/trinityal/tests/Shaders.vulkan/TexCoordAndPosition.vsh
@@ -1,0 +1,21 @@
+// Copyright © 2023 CCP ehf.
+
+struct VS_OUTPUT
+{
+	float4 Position : SV_Position;
+    float2 TexCoord : TEXCOORD;
+};
+
+struct VS_INPUT
+{
+    float2 TexCoord : TEXCOORD;
+    float3 Position : POSITION;
+};
+
+VS_OUTPUT main( VS_INPUT input )
+{
+	VS_OUTPUT Output;
+	Output.Position = float4(input.Position, 1);
+	Output.TexCoord = input.TexCoord;
+	return Output;    
+}

--- a/trinityal/tests/Shaders.vulkan/WriteToUav.psh
+++ b/trinityal/tests/Shaders.vulkan/WriteToUav.psh
@@ -1,0 +1,15 @@
+// Copyright © 2023 CCP ehf.
+
+struct VS_OUTPUT
+{
+	float4 Position : SV_Position;
+	float2 TexCoord : TEXCOORD;
+};
+
+RWTexture2D<float4> Output: register( u1, space1 );
+
+float4 main(VS_OUTPUT In) : SV_Target
+{
+    Output[uint2( In.TexCoord.xy * 64 )] = float4( In.TexCoord, 0, 1 );
+    return float4( In.TexCoord.yx, 0, 1 );
+}

--- a/trinityal/tests/StdAfx.h
+++ b/trinityal/tests/StdAfx.h
@@ -29,6 +29,8 @@ typedef uintptr_t Tr2WindowHandle;
 #define SHADER_PATH Shaders.DX11
 #elif ( TRINITY_PLATFORM == TRINITY_DIRECTX12 )
 #define SHADER_PATH Shaders.DX12
+#elif( TRINITY_PLATFORM==TRINITY_VULKAN )
+#define SHADER_PATH Shaders.vulkan
 #elif ( TRINITY_PLATFORM == TRINITY_METAL )
 #define SHADER_PATH Shaders.metal
 #else

--- a/trinityal/vulkan/Tr2BufferALVulkan.cpp
+++ b/trinityal/vulkan/Tr2BufferALVulkan.cpp
@@ -1,0 +1,234 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   April 2019
+//    Copyright: CCP 2019
+//
+
+#include "StdAfx.h"
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "Tr2BufferALVulkan.h"
+#include "Tr2PrimaryRenderContextVulkan.h"
+#include "UtilitiesVulkan.h"
+
+
+namespace TrinityALImpl
+{
+	Tr2BufferAL::Tr2BufferAL()
+		:m_buffer( VK_NULL_HANDLE ),
+		m_memory( VK_NULL_HANDLE ),
+		m_owner( nullptr )
+	{
+
+	}
+
+	Tr2BufferAL::~Tr2BufferAL()
+	{
+		Destroy();
+	}
+
+	ALResult Tr2BufferAL::Create(
+		const Tr2BufferDescriptionAL& desc,
+		const void* initialData,
+		Tr2PrimaryRenderContextAL& renderContext )
+	{
+		Destroy();
+
+		if( desc.count == 0 )
+		{
+			return E_INVALIDARG;
+		}
+
+		if( !renderContext.IsValid() )
+		{
+			return E_INVALIDCALL;
+		}
+
+		bool isImmutable = !HasFlag( desc.cpuUsage, Tr2CpuUsage::WRITE ) && !HasFlag( desc.gpuUsage, Tr2GpuUsage::UNORDERED_ACCESS );
+		if( isImmutable && !initialData )
+		{
+			return E_INVALIDARG;
+		}
+
+		if( HasFlag( desc.cpuUsage, Tr2CpuUsage::READ ) && HasFlag( desc.cpuUsage, Tr2CpuUsage::WRITE ) )
+		{
+			return E_INVALIDARG;
+		}
+
+		auto stride = desc.stride;
+		if( desc.format != Tr2RenderContextEnum::PIXEL_FORMAT_UNKNOWN )
+		{
+			stride = GetBytesPerPixel( desc.format );
+		}
+
+		if( HasFlag( desc.gpuUsage, Tr2GpuUsage::INDEX_BUFFER ) && stride != 2 && stride != 4 )
+		{
+			return E_INVALIDARG;
+		}
+
+		auto size = desc.count * stride;
+
+		VkBufferUsageFlags usage = 0;
+		if( initialData || HasFlag( desc.cpuUsage, Tr2CpuUsage::WRITE ) )
+		{
+			usage |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+		}
+		if( HasFlag( desc.gpuUsage, Tr2GpuUsage::INDEX_BUFFER ) )
+		{
+			usage |= VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
+		}
+		if( HasFlag( desc.gpuUsage, Tr2GpuUsage::VERTEX_BUFFER ) )
+		{
+			usage |= VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+		}
+		if( HasFlag( desc.gpuUsage, Tr2GpuUsage::DRAW_INDIRECT_ARGS ) )
+		{
+			usage |= VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
+		}
+		if( HasFlag( desc.gpuUsage, Tr2GpuUsage::SHADER_RESOURCE ) )
+		{
+			return E_NOTIMPL;
+		}
+		if( HasFlag( desc.gpuUsage, Tr2GpuUsage::UNORDERED_ACCESS ) )
+		{
+			return E_NOTIMPL;
+		}
+
+		VkBuffer buffer = VK_NULL_HANDLE;
+		VkDeviceMemory memory = VK_NULL_HANDLE;
+		FORWARD_HR( CreateBuffer( buffer, memory, size, usage, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, renderContext ) );
+		ON_BLOCK_EXIT( [&] {
+			
+			if( buffer ) renderContext.DestroyLaterVulkan( buffer, &vkDestroyBuffer );
+			if( memory ) renderContext.DestroyLaterVulkan( memory, &vkFreeMemory );
+		} );
+
+		if( initialData )
+		{
+			VkBuffer stagingBuffer = VK_NULL_HANDLE;
+			VkDeviceMemory stagingMemory = VK_NULL_HANDLE;
+			FORWARD_HR( CreateBuffer( stagingBuffer, stagingMemory, size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, renderContext ) );
+
+			ON_BLOCK_EXIT( [&] {
+				if( stagingBuffer ) renderContext.DestroyLaterVulkan( stagingBuffer, &vkDestroyBuffer );
+				if( stagingMemory ) renderContext.DestroyLaterVulkan( stagingMemory, &vkFreeMemory );
+			} );
+
+
+			void *mapped;
+			CR_RETURN_HR( Vk2Al( vkMapMemory( renderContext.m_device, stagingMemory, 0, size, 0, &mapped ) ) );
+			memcpy( mapped, initialData, size );
+
+			VkMappedMemoryRange flushRange = {
+				VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,
+				nullptr,
+				stagingMemory,
+				0,
+				VK_WHOLE_SIZE
+			};
+			vkFlushMappedMemoryRanges( renderContext.m_device, 1, &flushRange );
+			vkUnmapMemory( renderContext.m_device, stagingMemory );
+
+			VkBufferCopy copyInfo = { 0, 0, size };
+			vkCmdCopyBuffer( renderContext.m_commandBuffer, stagingBuffer, buffer, 1, &copyInfo );
+
+			VkBufferMemoryBarrier barrier = {
+				VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
+				nullptr,
+				VK_ACCESS_MEMORY_WRITE_BIT,
+				VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT,
+				VK_QUEUE_FAMILY_IGNORED,
+				VK_QUEUE_FAMILY_IGNORED,
+				buffer,
+				0,
+				VK_WHOLE_SIZE
+			};
+			vkCmdPipelineBarrier( renderContext.m_commandBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, 0, 0, nullptr, 1, &barrier, 0, nullptr );
+		}
+
+		m_buffer = buffer;
+		buffer = VK_NULL_HANDLE;
+		m_memory = memory;
+		memory = VK_NULL_HANDLE;
+
+		m_owner = &renderContext;
+		m_desc = desc;
+
+		return S_OK;
+	}
+
+	void Tr2BufferAL::Destroy()
+	{
+		if( m_buffer )
+		{
+			m_owner->DestroyLaterVulkan( m_buffer, &vkDestroyBuffer );
+			m_buffer = VK_NULL_HANDLE;
+
+			m_owner->DestroyLaterVulkan( m_memory, &vkFreeMemory );
+			m_memory = VK_NULL_HANDLE;
+
+			m_owner = nullptr;
+			m_desc = Tr2BufferDescriptionAL();
+		}
+	}
+
+	bool Tr2BufferAL::IsValid() const
+	{
+		return m_buffer != VK_NULL_HANDLE;
+	}
+
+	Tr2ALMemoryType Tr2BufferAL::GetMemoryClass() const
+	{
+		return AL_MEMORY_VIDEO;
+	}
+
+	const Tr2BufferDescriptionAL& Tr2BufferAL::GetDesc() const
+	{
+		return m_desc;
+	}
+
+	ALResult Tr2BufferAL::MapForReading( const void*& data, Tr2RenderContextAL& renderContext )
+	{
+		return E_NOTIMPL;
+	}
+	void Tr2BufferAL::UnmapForReading( Tr2RenderContextAL& renderContext )
+	{
+	}
+	ALResult Tr2BufferAL::MapForWriting( void*& data, Tr2LockType::Type lockType, Tr2RenderContextAL& renderContext )
+	{
+		return E_NOTIMPL;
+	}
+	void Tr2BufferAL::UnmapForWriting( Tr2RenderContextAL& renderContext )
+	{
+	}
+
+	ALResult Tr2BufferAL::UpdateBuffer( uint32_t offset, uint32_t size, const void* data, Tr2RenderContextAL & renderContext )
+	{
+		return E_NOTIMPL;;
+	}
+
+	uint32_t Tr2BufferAL::GetSrvIndexInHeap() const
+	{
+		return 0xffffffff;
+	}
+
+	uint32_t Tr2BufferAL::GetUavIndexInHeap() const
+	{
+		return 0xffffffff;
+	}
+
+	void Tr2BufferAL::Describe( Tr2DeviceResourceDescriptionAL& description ) const
+	{
+		description["type"] = "Tr2BufferAL";
+		description["size"] = std::to_string( GetDesc().count * GetDesc().stride );
+	}
+
+	ALResult Tr2BufferAL::SetName( const char* )
+	{
+		return E_NOTIMPL;
+	}
+}
+
+
+#endif

--- a/trinityal/vulkan/Tr2BufferALVulkan.cpp
+++ b/trinityal/vulkan/Tr2BufferALVulkan.cpp
@@ -18,6 +18,7 @@ namespace TrinityALImpl
 	Tr2BufferAL::Tr2BufferAL()
 		:m_buffer( VK_NULL_HANDLE ),
 		m_memory( VK_NULL_HANDLE ),
+		m_bufferView( VK_NULL_HANDLE ),
 		m_owner( nullptr )
 	{
 
@@ -86,13 +87,14 @@ namespace TrinityALImpl
 		{
 			usage |= VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
 		}
+		const bool isTypedBuffer = desc.format != Tr2RenderContextEnum::PIXEL_FORMAT_UNKNOWN;
 		if( HasFlag( desc.gpuUsage, Tr2GpuUsage::SHADER_RESOURCE ) )
 		{
-			return E_NOTIMPL;
+			usage |= isTypedBuffer ? VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT : VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 		}
 		if( HasFlag( desc.gpuUsage, Tr2GpuUsage::UNORDERED_ACCESS ) )
 		{
-			return E_NOTIMPL;
+			usage |= isTypedBuffer ? VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT : VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 		}
 
 		VkBuffer buffer = VK_NULL_HANDLE;
@@ -147,10 +149,27 @@ namespace TrinityALImpl
 			vkCmdPipelineBarrier( renderContext.m_commandBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, 0, 0, nullptr, 1, &barrier, 0, nullptr );
 		}
 
+		VkBufferView bufferView = VK_NULL_HANDLE;
+		if( isTypedBuffer && ( HasFlag( desc.gpuUsage, Tr2GpuUsage::SHADER_RESOURCE ) || HasFlag( desc.gpuUsage, Tr2GpuUsage::UNORDERED_ACCESS ) ) )
+		{
+			VkBufferViewCreateInfo viewInfo = {
+				VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO,
+				nullptr,
+				0,
+				buffer,
+				GetVulkanFormat( desc.format ),
+				0,
+				VK_WHOLE_SIZE
+			};
+			CR_RETURN_HR( Vk2Al( vkCreateBufferView( renderContext.m_device, &viewInfo, nullptr, &bufferView ) ) );
+		}
+
 		m_buffer = buffer;
 		buffer = VK_NULL_HANDLE;
 		m_memory = memory;
 		memory = VK_NULL_HANDLE;
+		m_bufferView = bufferView;
+		bufferView = VK_NULL_HANDLE;
 
 		m_owner = &renderContext;
 		m_desc = desc;
@@ -162,6 +181,12 @@ namespace TrinityALImpl
 	{
 		if( m_buffer )
 		{
+			if( m_bufferView )
+			{
+				m_owner->DestroyLaterVulkan( m_bufferView, &vkDestroyBufferView );
+				m_bufferView = VK_NULL_HANDLE;
+			}
+
 			m_owner->DestroyLaterVulkan( m_buffer, &vkDestroyBuffer );
 			m_buffer = VK_NULL_HANDLE;
 

--- a/trinityal/vulkan/Tr2BufferALVulkan.cpp
+++ b/trinityal/vulkan/Tr2BufferALVulkan.cpp
@@ -192,10 +192,14 @@ namespace TrinityALImpl
 	{
 		return E_NOTIMPL;
 	}
+	ALResult Tr2BufferAL::MapForReading( const void*& data, uint32_t offset, uint32_t size, Tr2RenderContextAL& renderContext )
+	{
+		return E_NOTIMPL;
+	}
 	void Tr2BufferAL::UnmapForReading( Tr2RenderContextAL& renderContext )
 	{
 	}
-	ALResult Tr2BufferAL::MapForWriting( void*& data, Tr2LockType::Type lockType, Tr2RenderContextAL& renderContext )
+	ALResult Tr2BufferAL::MapForWriting( void*& data, Tr2RenderContextAL& renderContext )
 	{
 		return E_NOTIMPL;
 	}

--- a/trinityal/vulkan/Tr2BufferALVulkan.h
+++ b/trinityal/vulkan/Tr2BufferALVulkan.h
@@ -1,0 +1,52 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   February 2019
+//    Copyright: CCP 2019
+//
+
+#pragma once
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "../include/Tr2BufferAL.h"
+
+namespace TrinityALImpl
+{
+	class Tr2BufferAL : public Tr2DeviceResourceAL<Tr2BufferAL>
+	{
+	public:
+		Tr2BufferAL();
+		~Tr2BufferAL();
+
+		ALResult Create(
+			const Tr2BufferDescriptionAL& desc,
+			const void* initialData,
+			Tr2PrimaryRenderContextAL& renderContext );
+		void Destroy();
+		bool IsValid() const;
+
+		Tr2ALMemoryType GetMemoryClass() const;
+		const Tr2BufferDescriptionAL& GetDesc() const;
+
+		ALResult MapForReading( const void*& data, Tr2RenderContextAL& renderContext );
+		void UnmapForReading( Tr2RenderContextAL& renderContext );
+		ALResult MapForWriting( void*& data, Tr2LockType::Type lockType, Tr2RenderContextAL& renderContext );
+		void UnmapForWriting( Tr2RenderContextAL& renderContext );
+		ALResult UpdateBuffer( uint32_t offset, uint32_t size, const void* data, Tr2RenderContextAL & renderContext );
+		void Describe( Tr2DeviceResourceDescriptionAL& description ) const;
+		ALResult SetName( const char* name );
+
+		uint32_t GetSrvIndexInHeap() const;
+		uint32_t GetUavIndexInHeap() const;
+
+	private:
+		VkBuffer m_buffer;
+		VkDeviceMemory m_memory;
+		Tr2PrimaryRenderContextAL* m_owner;
+		Tr2BufferDescriptionAL m_desc;
+
+		friend class Tr2RenderContextAL;
+	};
+}
+
+#endif

--- a/trinityal/vulkan/Tr2BufferALVulkan.h
+++ b/trinityal/vulkan/Tr2BufferALVulkan.h
@@ -40,13 +40,18 @@ namespace TrinityALImpl
 		uint32_t GetSrvIndexInHeap() const;
 		uint32_t GetUavIndexInHeap() const;
 
+		VkBuffer GetBufferVulkan() const { return m_buffer; }
+		VkBufferView GetBufferViewVulkan() const { return m_bufferView; }
+
 	private:
 		VkBuffer m_buffer;
 		VkDeviceMemory m_memory;
+		VkBufferView m_bufferView;
 		Tr2PrimaryRenderContextAL* m_owner;
 		Tr2BufferDescriptionAL m_desc;
 
 		friend class Tr2RenderContextAL;
+		friend class Tr2ResourceSetAL;
 	};
 }
 

--- a/trinityal/vulkan/Tr2BufferALVulkan.h
+++ b/trinityal/vulkan/Tr2BufferALVulkan.h
@@ -29,8 +29,9 @@ namespace TrinityALImpl
 		const Tr2BufferDescriptionAL& GetDesc() const;
 
 		ALResult MapForReading( const void*& data, Tr2RenderContextAL& renderContext );
+		ALResult MapForReading( const void*& data, uint32_t offset, uint32_t size, Tr2RenderContextAL& renderContext );
 		void UnmapForReading( Tr2RenderContextAL& renderContext );
-		ALResult MapForWriting( void*& data, Tr2LockType::Type lockType, Tr2RenderContextAL& renderContext );
+		ALResult MapForWriting( void*& data, Tr2RenderContextAL& renderContext );
 		void UnmapForWriting( Tr2RenderContextAL& renderContext );
 		ALResult UpdateBuffer( uint32_t offset, uint32_t size, const void* data, Tr2RenderContextAL & renderContext );
 		void Describe( Tr2DeviceResourceDescriptionAL& description ) const;

--- a/trinityal/vulkan/Tr2CapsALVulkan.h
+++ b/trinityal/vulkan/Tr2CapsALVulkan.h
@@ -1,0 +1,59 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   February 2019
+//    Copyright: CCP 2019
+//
+
+#pragma once
+
+#if TRINITY_PLATFORM==TRINITY_VULKAN
+
+#define TRINITY_PLATFORM_SUPPORTS_BUFFER_SHADER_RESOURCES 1
+#define TRINITY_PLATFORM_SUPPORTS_BUFFER_COUNTERS 0
+#define TRINITY_PLATFORM_SUPPORTS_UNORDERED_ACCESS 1
+#define TRINITY_PLATFORM_SUPPORTS_COMPUTE 1
+#define TRINITY_PLATFORM_SUPPORTS_TEXTURE_ARRAYS 1
+#define TRINITY_PLATFORM_SUPPORTS_MSAA_SAMPLE 1
+#define TRINITY_PLATFORM_SUPPORTS_RENDER_PASS_HINTS 0
+#define TRINITY_PLATFORM_IS_LOW_PERFORMACE 0
+#define TRINITY_PLATFORM_MAX_CONSTANT_BUFFER_SIZE ( 64 * 1024 )
+#define TRINITY_PLATFORM_SUPPORTS_RAY_TRACING 0
+
+
+class Tr2CapsAL
+{
+public:
+	bool SupportsFloat16() const
+	{
+		return true;
+	}
+	bool SupportsGpuBuffer() const
+	{
+		return true;
+	}
+	bool SupportsStandaloneSwapChain() const
+	{
+		return true;
+	}
+	bool SupportsVertexShaderTextures() const
+	{
+		return true;
+	}
+	bool SupportsVariableRefreshRate() const
+	{
+		return false;
+	}
+	bool SupportsRaytracing() const
+	{
+		return false;
+	}
+
+private:
+	Tr2CapsAL() {}
+	Tr2CapsAL( const Tr2CapsAL& ) {}
+	Tr2CapsAL& operator=( const Tr2CapsAL& ) { return *this; }
+
+	friend class Tr2PrimaryRenderContextAL;
+};
+
+#endif

--- a/trinityal/vulkan/Tr2ConstantBufferALVulkan.cpp
+++ b/trinityal/vulkan/Tr2ConstantBufferALVulkan.cpp
@@ -1,0 +1,154 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   August 2019
+//    Copyright: CCP 2019
+//
+
+#include "StdAfx.h"
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "Tr2ConstantBufferALVulkan.h"
+#include "Tr2PrimaryRenderContextVulkan.h"
+#include "UtilitiesVulkan.h"
+
+namespace TrinityALImpl
+{
+
+	Tr2ConstantBufferAL::Tr2ConstantBufferAL()
+		:m_buffer( VK_NULL_HANDLE ),
+		m_memory( VK_NULL_HANDLE ),
+		m_owner( nullptr ),
+		m_size( 0 )
+	{
+	}
+
+	Tr2ConstantBufferAL::~Tr2ConstantBufferAL()
+	{
+		Destroy();
+	}
+
+	ALResult Tr2ConstantBufferAL::Create( uint32_t size, Tr2ConstantUsageAL::Type usage, const void* initialData, Tr2PrimaryRenderContextAL& renderContext )
+	{
+		Destroy();
+
+		if( size == 0 )
+		{
+			return E_INVALIDARG;
+		}
+
+		if( !renderContext.IsValid() )
+		{
+			return E_INVALIDCALL;
+		}
+
+		VkBuffer buffer = VK_NULL_HANDLE;
+		VkDeviceMemory memory = VK_NULL_HANDLE;
+		FORWARD_HR( TrinityALImpl::CreateBuffer( buffer, memory, size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VkMemoryPropertyFlagBits( VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT ), renderContext ) );
+		ON_BLOCK_EXIT( [&] {
+			if( buffer ) renderContext.DestroyLaterVulkan( buffer, &vkDestroyBuffer );
+			if( memory ) renderContext.DestroyLaterVulkan( memory, &vkFreeMemory );
+			} );
+
+		if( initialData )
+		{
+			void* mapped;
+			CR_RETURN_HR( Vk2Al( vkMapMemory( renderContext.m_device, memory, 0, size, 0, &mapped ) ) );
+			memcpy( mapped, initialData, size );
+
+			VkMappedMemoryRange flushRange = {
+				VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,
+				nullptr,
+				memory,
+				0,
+				VK_WHOLE_SIZE
+			};
+			vkFlushMappedMemoryRanges( renderContext.m_device, 1, &flushRange );
+			vkUnmapMemory( renderContext.m_device, memory );
+		}
+
+		m_buffer = buffer;
+		buffer = VK_NULL_HANDLE;
+		m_memory = memory;
+		memory = VK_NULL_HANDLE;
+
+		m_owner = &renderContext;
+		m_size = size;
+
+		return S_OK;
+	}
+
+	ALResult Tr2ConstantBufferAL::Lock( void** data, Tr2RenderContextAL& )
+	{
+		if( !IsValid() )
+		{
+			return E_INVALIDCALL;
+		}
+		return Vk2Al( vkMapMemory( m_owner->m_device, m_memory, 0, VK_WHOLE_SIZE, 0, data ) );
+	}
+
+	ALResult Tr2ConstantBufferAL::Unlock( Tr2RenderContextAL& renderContext )
+	{
+		if( !IsValid() )
+		{
+			return E_INVALIDCALL;
+		}
+		VkMappedMemoryRange flushRange = {
+			VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,
+			nullptr,
+			m_memory,
+			0,
+			VK_WHOLE_SIZE
+		};
+		vkFlushMappedMemoryRanges( m_owner->m_device, 1, &flushRange );
+		vkUnmapMemory( m_owner->m_device, m_memory );
+		return S_OK;
+	}
+
+	bool Tr2ConstantBufferAL::IsValid() const
+	{
+		return m_owner != nullptr;
+	}
+
+	void Tr2ConstantBufferAL::Destroy()
+	{
+		if( m_owner )
+		{
+			m_owner->DestroyLaterVulkan( m_buffer, &vkDestroyBuffer );
+			m_buffer = VK_NULL_HANDLE;
+
+			m_owner->DestroyLaterVulkan( m_memory, &vkFreeMemory );
+			m_memory = VK_NULL_HANDLE;
+
+			m_owner = nullptr;
+			m_size = 0;
+		}
+	}
+
+	Tr2ConstantUsageAL::Type Tr2ConstantBufferAL::GetUsage() const
+	{
+		return Tr2ConstantUsageAL::REUSABLE;
+	}
+
+	uint32_t Tr2ConstantBufferAL::GetSize() const
+	{
+		return m_size;
+	}
+
+	Tr2ALMemoryType Tr2ConstantBufferAL::GetMemoryClass() const
+	{
+		return AL_MEMORY_MANAGED;
+	}
+
+	void Tr2ConstantBufferAL::Describe( Tr2DeviceResourceDescriptionAL& description ) const
+	{
+		description["type"] = "Tr2ConstantBufferAL";
+	}
+
+	ALResult Tr2ConstantBufferAL::SetName( const char* )
+	{
+		return E_NOTIMPL;
+	}
+}
+
+#endif

--- a/trinityal/vulkan/Tr2ConstantBufferALVulkan.h
+++ b/trinityal/vulkan/Tr2ConstantBufferALVulkan.h
@@ -1,0 +1,56 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   February 2019
+//    Copyright: CCP 2019
+//
+
+#pragma once
+
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "../include/Tr2ConstantBufferAL.h"
+
+namespace TrinityALImpl
+{
+	// -------------------------------------------------------------
+	// Description:
+	//   A low level wrapper around the calls needed to set up a constant
+	//   buffer for a given platform. Any higher level logic should be
+	//   handled one level up, this is only to avoid ifdef soup when
+	//   creating and locking buffers.
+	//	 32bit: no support for 64bit-sized buffers.
+	// -------------------------------------------------------------
+	class Tr2ConstantBufferAL: public Tr2DeviceResourceAL<Tr2ConstantBufferAL>
+	{
+	public:
+		Tr2ConstantBufferAL();
+		~Tr2ConstantBufferAL();
+
+		ALResult Create( uint32_t size, Tr2ConstantUsageAL::Type usage, const void* initialData, Tr2PrimaryRenderContextAL& renderContext );
+
+		ALResult Lock( void** data, Tr2RenderContextAL& renderContext );
+		ALResult Unlock( Tr2RenderContextAL& renderContext );
+
+		bool IsValid() const;
+
+		void Destroy();
+
+		Tr2ConstantUsageAL::Type GetUsage() const;
+		uint32_t GetSize() const;
+
+		Tr2ALMemoryType GetMemoryClass() const;
+		void Describe( Tr2DeviceResourceDescriptionAL& description ) const;
+		ALResult SetName( const char* name );
+
+	private:
+		Tr2ConstantBufferAL( const Tr2ConstantBufferAL& ) /* = delete */;
+		Tr2ConstantBufferAL& operator=( const Tr2ConstantBufferAL& ) /* = delete */;
+
+		VkBuffer m_buffer;
+		VkDeviceMemory m_memory;
+		Tr2PrimaryRenderContextAL* m_owner;
+		uint32_t m_size;
+	};
+}
+#endif

--- a/trinityal/vulkan/Tr2ConstantBufferALVulkan.h
+++ b/trinityal/vulkan/Tr2ConstantBufferALVulkan.h
@@ -38,6 +38,7 @@ namespace TrinityALImpl
 
 		Tr2ConstantUsageAL::Type GetUsage() const;
 		uint32_t GetSize() const;
+		VkBuffer GetBufferVulkan() const { return m_buffer; }
 
 		Tr2ALMemoryType GetMemoryClass() const;
 		void Describe( Tr2DeviceResourceDescriptionAL& description ) const;

--- a/trinityal/vulkan/Tr2FenceALVulkan.h
+++ b/trinityal/vulkan/Tr2FenceALVulkan.h
@@ -1,0 +1,75 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   February 2019
+//    Copyright: CCP 2019
+//
+
+#pragma once
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "../include/Tr2FenceAL.h"
+
+namespace TrinityALImpl
+{
+	class Tr2FenceAL :
+		public Tr2DeviceResourceAL<Tr2FenceAL>
+	{
+	public:
+		Tr2FenceAL()
+		{
+
+		}
+		~Tr2FenceAL()
+		{
+
+		}
+
+		ALResult Create( Tr2PrimaryRenderContextAL& renderContext )
+		{
+			return E_NOTIMPL;
+		}
+		void Destroy()
+		{
+
+		}
+
+		bool IsValid() const
+		{
+			return false;
+		}
+
+		ALResult PutFence( Tr2RenderContextAL& renderContext )
+		{
+			return E_NOTIMPL;
+		}
+		ALResult IsReached( bool& isReached, Tr2RenderContextAL& renderContext )
+		{
+			return E_NOTIMPL;
+		}
+		ALResult Wait( Tr2RenderContextAL& renderContext )
+		{
+			return E_NOTIMPL;
+		}
+
+		bool operator==( const Tr2FenceAL& other ) const
+		{
+			return this == &other;
+		}
+
+		Tr2ALMemoryType GetMemoryClass() const { return AL_MEMORY_VIDEO; }
+		void Describe( Tr2DeviceResourceDescriptionAL& description ) const
+		{
+		}
+		ALResult SetName( const char* name )
+		{
+			return E_NOTIMPL;
+		}
+
+	private:
+		Tr2FenceAL( const Tr2FenceAL& ) /* = delete */;
+		Tr2FenceAL& operator=( const Tr2FenceAL& ) /* = delete */;
+	};
+}
+
+#endif

--- a/trinityal/vulkan/Tr2GpuTimerALVulkan.h
+++ b/trinityal/vulkan/Tr2GpuTimerALVulkan.h
@@ -1,0 +1,73 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   February 2019
+//    Copyright: CCP 2019
+//
+
+#pragma once
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+
+#include "../include/Tr2GpuTimerAL.h"
+
+
+namespace TrinityALImpl
+{
+	class Tr2GpuTimerAL :
+		public Tr2DeviceResourceAL<Tr2GpuTimerAL>
+	{
+	public:
+		Tr2GpuTimerAL()
+		{
+
+		}
+
+		ALResult Create( Tr2PrimaryRenderContextAL& renderContext )
+		{
+			return E_NOTIMPL;
+		}
+
+		void Destroy()
+		{
+
+		}
+
+		bool Begin( Tr2RenderContextAL& renderContext )
+		{
+			return false;
+		}
+
+		void End( Tr2RenderContextAL& renderContext )
+		{
+
+		}
+
+		float GetTime( Tr2RenderContextAL& renderContext )
+		{
+			return 0;
+		}
+
+		bool IsValid() const
+		{
+			return false;
+		}
+
+		bool operator==(const Tr2GpuTimerAL& other) const
+		{
+			return this == &other;
+		}
+
+		Tr2ALMemoryType GetMemoryClass() const { return AL_MEMORY_VIDEO; }
+		void Describe( Tr2DeviceResourceDescriptionAL& description ) const
+		{
+		}
+		ALResult SetName( const char* name )
+		{
+			return E_NOTIMPL;
+		}
+	};
+	}
+
+
+#endif

--- a/trinityal/vulkan/Tr2OcclusionQueryALVulkan.h
+++ b/trinityal/vulkan/Tr2OcclusionQueryALVulkan.h
@@ -1,0 +1,63 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   February 2019
+//    Copyright: CCP 2019
+//
+
+#pragma once
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "../include/Tr2OcclusionQueryAL.h"
+
+namespace TrinityALImpl
+{
+	class Tr2OcclusionQueryAL : public Tr2DeviceResourceAL<Tr2OcclusionQueryAL>
+	{
+	public:
+		Tr2OcclusionQueryAL() {}
+
+		ALResult Create( Tr2PrimaryRenderContextAL& renderContext )
+		{
+			return E_NOTIMPL;
+		}
+		bool IsValid() const
+		{
+			return false;
+		}
+		void Destroy()
+		{
+
+		}
+
+		ALResult Begin( Tr2RenderContextAL& renderContext )
+		{
+			return E_NOTIMPL;
+		}
+		ALResult End( Tr2RenderContextAL& renderContext )
+		{
+			return E_NOTIMPL;
+		}
+		ALResult GetPixelCount( Tr2RenderContextAL& renderContext, uint32_t& count, ::Tr2OcclusionQueryAL::WaitMode waitMode )
+		{
+			return E_NOTIMPL;
+		}
+
+		bool operator==( const Tr2OcclusionQueryAL& other ) const { return false; }
+
+		Tr2ALMemoryType GetMemoryClass() const { return AL_MEMORY_MANAGED; }
+		void Describe( Tr2DeviceResourceDescriptionAL& description ) const
+		{
+		}
+		ALResult SetName( const char* name )
+		{
+			return E_NOTIMPL;
+		}
+
+	private:
+		Tr2OcclusionQueryAL( const Tr2OcclusionQueryAL& ) /* = delete */;
+		Tr2OcclusionQueryAL& operator=( const Tr2OcclusionQueryAL& ) /* = delete */;
+	};
+}
+
+#endif

--- a/trinityal/vulkan/Tr2PipelineStatsQueryALVulkan.cpp
+++ b/trinityal/vulkan/Tr2PipelineStatsQueryALVulkan.cpp
@@ -1,0 +1,75 @@
+#include "StdAfx.h"
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+#include "Tr2PipelineStatsQueryALVulkan.h"
+
+
+namespace TrinityALImpl
+{
+
+Tr2PipelineStatsQueryAL::Tr2PipelineStatsQueryAL()
+{
+}
+
+ALResult Tr2PipelineStatsQueryAL::Create( Tr2PrimaryRenderContextAL& renderContext )
+{
+	return S_OK;
+}
+
+bool Tr2PipelineStatsQueryAL::IsValid() const
+{
+	return true;
+}
+
+void Tr2PipelineStatsQueryAL::Destroy()
+{
+}
+
+ALResult Tr2PipelineStatsQueryAL::Begin( Tr2RenderContextAL& renderContext )
+{
+	return S_OK;
+}
+
+ALResult Tr2PipelineStatsQueryAL::End( Tr2RenderContextAL& renderContext )
+{
+	return S_OK;
+}
+
+ALResult Tr2PipelineStatsQueryAL::GetStats( Tr2PipelineStatsDataAL& data, Tr2RenderContextAL& renderContext )
+{
+	return S_OK;
+}
+
+size_t Tr2PipelineStatsQueryAL::GetValueCount( const Tr2PipelineStatsDataAL& data )
+{
+	return 0;
+}
+
+const char* Tr2PipelineStatsQueryAL::GetLabel( const Tr2PipelineStatsDataAL& data, size_t index )
+{
+	return "";
+}
+
+const char* Tr2PipelineStatsQueryAL::GetDescription( const Tr2PipelineStatsDataAL& data, size_t index )
+{
+	return "";
+}
+
+::Tr2PipelineStatsQueryAL::Value Tr2PipelineStatsQueryAL::GetValue( const Tr2PipelineStatsDataAL& data, size_t index )
+{
+	return 0;
+}
+
+void Tr2PipelineStatsQueryAL::Describe( Tr2DeviceResourceDescriptionAL& description ) const
+{
+	description["type"] = "Tr2PipelineStatsQueryAL";
+}
+
+ALResult Tr2PipelineStatsQueryAL::SetName( const char* )
+{
+	return E_NOTIMPL;
+}
+
+}
+
+#endif

--- a/trinityal/vulkan/Tr2PipelineStatsQueryALVulkan.h
+++ b/trinityal/vulkan/Tr2PipelineStatsQueryALVulkan.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "../include/Tr2PipelineStatsQueryAL.h"
+
+namespace TrinityALImpl
+{
+class Tr2PipelineStatsDataAL
+{
+};
+
+
+class Tr2PipelineStatsQueryAL : public Tr2DeviceResourceAL<Tr2PipelineStatsQueryAL>
+{
+public:
+	Tr2PipelineStatsQueryAL();
+
+	ALResult Create( Tr2PrimaryRenderContextAL& renderContext );
+	bool IsValid() const;
+	void Destroy();
+
+	ALResult Begin( Tr2RenderContextAL& renderContext );
+	ALResult End( Tr2RenderContextAL& renderContext );
+
+	ALResult GetStats( Tr2PipelineStatsDataAL& data, Tr2RenderContextAL& renderContext );
+
+	static size_t GetValueCount( const Tr2PipelineStatsDataAL& data );
+	static const char* GetLabel( const Tr2PipelineStatsDataAL& data, size_t index );
+	static const char* GetDescription( const Tr2PipelineStatsDataAL& data, size_t index );
+	static ::Tr2PipelineStatsQueryAL::Value GetValue( const Tr2PipelineStatsDataAL& data, size_t index );
+
+	Tr2ALMemoryType GetMemoryClass() const
+	{
+		return AL_MEMORY_MANAGED;
+	}
+	void Describe( Tr2DeviceResourceDescriptionAL& description ) const;
+	ALResult SetName( const char* name );
+
+private:
+	Tr2PipelineStatsQueryAL( const Tr2PipelineStatsQueryAL& ) = delete;
+	Tr2PipelineStatsQueryAL& operator=( const Tr2PipelineStatsQueryAL& ) = delete;
+};
+
+}
+
+#endif

--- a/trinityal/vulkan/Tr2PrimaryRenderContextVulkan.cpp
+++ b/trinityal/vulkan/Tr2PrimaryRenderContextVulkan.cpp
@@ -1,0 +1,658 @@
+#include "StdAfx.h"
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "Tr2PrimaryRenderContextVulkan.h"
+#include "Tr2VideoAdapterInfoALVulkan.h"
+#include "ALLog.h"
+#include "VkResult.h"
+#include "ITr2RenderContextEvents.h"
+#include "Tr2AdapterStructures.h"
+#include "UtilitiesVulkan.h"
+#include "Tr2TextureALVulkan.h"
+
+namespace
+{
+	bool FindPresentableQueues( VkPhysicalDevice device, VkSurfaceKHR surface, uint32_t& graphicsQueue, uint32_t& presentQueue )
+	{
+		graphicsQueue = 0xffffffff;
+		presentQueue = 0xffffffff;
+
+		std::vector<VkQueueFamilyProperties> queue_family_properties;
+		TrinityALImpl::QueryArrayNoFail( &vkGetPhysicalDeviceQueueFamilyProperties, device, queue_family_properties );
+		if( queue_family_properties.empty() )
+		{
+			return false;
+		}
+
+		std::vector<VkBool32> presentSupport( queue_family_properties.size() );
+
+		for( uint32_t j = 0; j < uint32_t( queue_family_properties.size() ); ++j )
+		{
+			vkGetPhysicalDeviceSurfaceSupportKHR( device, j, surface, &presentSupport[j] );
+
+			if( ( queue_family_properties[j].queueCount > 0 ) && ( queue_family_properties[j].queueFlags & VK_QUEUE_GRAPHICS_BIT ) )
+			{
+				if( graphicsQueue == 0xffffffff )
+				{
+					graphicsQueue = j;
+				}
+				if( presentSupport[j] )
+				{
+					graphicsQueue = j;
+					presentQueue = j;
+					return true;
+				}
+			}
+		}
+		if( graphicsQueue == 0xffffffff )
+		{
+			return false;
+		}
+		for( uint32_t i = 0; i < uint32_t( queue_family_properties.size() ); ++i )
+		{
+			if( presentSupport[i] )
+			{
+				presentQueue = i;
+				return true;
+			}
+		}
+		return false;
+	}
+
+	uint32_t GetSwapChainNumImages( VkSurfaceCapabilitiesKHR &surfaceCapabilities ) 
+	{
+		// Set of images defined in a swap chain may not always be available for application to render to:
+		// One may be displayed and one may wait in a queue to be presented
+		// If application wants to use more images at the same time it must ask for more images
+		uint32_t count = surfaceCapabilities.minImageCount + 1;
+		if( ( surfaceCapabilities.maxImageCount > 0 ) && ( count > surfaceCapabilities.maxImageCount ) ) 
+		{
+			count = surfaceCapabilities.maxImageCount;
+		}
+		return count;
+	}
+
+	VkSurfaceFormatKHR GetSwapChainFormat( std::vector<VkSurfaceFormatKHR> &surfaceFormats ) 
+	{
+		// If the list contains only one entry with undefined format
+		// it means that there are no preferred surface formats and any can be chosen
+		if( ( surfaceFormats.size() == 1 ) && ( surfaceFormats[0].format == VK_FORMAT_UNDEFINED ) ) 
+		{
+			VkSurfaceFormatKHR fmt = { VK_FORMAT_R8G8B8A8_UNORM, VK_COLORSPACE_SRGB_NONLINEAR_KHR };
+			return fmt;
+		}
+
+		// Check if list contains most widely used R8 G8 B8 A8 format
+		// with nonlinear color space
+		for( auto surfaceFormat = begin( surfaceFormats ); surfaceFormat != end( surfaceFormats ); ++surfaceFormat )
+		{
+			if( surfaceFormat->format == VK_FORMAT_R8G8B8A8_UNORM ) 
+			{
+				return *surfaceFormat;
+			}
+		}
+
+		// Return the first format from the list
+		return surfaceFormats[0];
+	}
+
+	VkExtent2D GetSwapChainExtent( VkSurfaceCapabilitiesKHR &surfaceCapabilities ) 
+	{
+		// Special value of surface extent is width == height == -1
+		// If this is so we define the size by ourselves but it must fit within defined confines
+		if( surfaceCapabilities.currentExtent.width == -1 ) 
+		{
+			VkExtent2D swap_chain_extent = { 640, 480 };
+			if( swap_chain_extent.width < surfaceCapabilities.minImageExtent.width ) 
+			{
+				swap_chain_extent.width = surfaceCapabilities.minImageExtent.width;
+			}
+			if( swap_chain_extent.height < surfaceCapabilities.minImageExtent.height ) 
+			{
+				swap_chain_extent.height = surfaceCapabilities.minImageExtent.height;
+			}
+			if( swap_chain_extent.width > surfaceCapabilities.maxImageExtent.width ) 
+			{
+				swap_chain_extent.width = surfaceCapabilities.maxImageExtent.width;
+			}
+			if( swap_chain_extent.height > surfaceCapabilities.maxImageExtent.height ) 
+			{
+				swap_chain_extent.height = surfaceCapabilities.maxImageExtent.height;
+			}
+			return swap_chain_extent;
+		}
+
+		// Most of the cases we define size of the swap_chain images equal to current window's size
+		return surfaceCapabilities.currentExtent;
+	}
+
+	VkImageUsageFlags GetSwapChainUsageFlags( VkSurfaceCapabilitiesKHR &surface_capabilities ) 
+	{
+		// Color attachment flag must always be supported
+		// We can define other usage flags but we always need to check if they are supported
+		if( surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_DST_BIT ) 
+		{
+			return VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+		}
+		return static_cast<VkImageUsageFlags>( -1 );
+	}
+
+	VkSurfaceTransformFlagBitsKHR GetSwapChainTransform( VkSurfaceCapabilitiesKHR &surface_capabilities ) 
+	{
+		// Sometimes images must be transformed before they are presented (i.e. due to device's orienation
+		// being other than default orientation)
+		// If the specified transform is other than current transform, presentation engine will transform image
+		// during presentation operation; this operation may hit performance on some platforms
+		// Here we don't want any transformations to occur so if the identity transform is supported use it
+		// otherwise just use the same transform as current transform
+		if( surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR ) 
+		{
+			return VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+		}
+		else 
+		{
+			return surface_capabilities.currentTransform;
+		}
+	}
+
+	VkPresentModeKHR GetSwapChainPresentMode( Tr2RenderContextEnum::PresentInterval interval, std::vector<VkPresentModeKHR> &present_modes ) 
+	{
+		if( interval == Tr2RenderContextEnum::PRESENT_INTERVAL_IMMEDIATE )
+		{
+			if( std::find( begin( present_modes ), end( present_modes ), VK_PRESENT_MODE_IMMEDIATE_KHR ) != end( present_modes ) )
+			{
+				return VK_PRESENT_MODE_IMMEDIATE_KHR;
+			}
+			if( std::find( begin( present_modes ), end( present_modes ), VK_PRESENT_MODE_MAILBOX_KHR ) != end( present_modes ) )
+			{
+				return VK_PRESENT_MODE_MAILBOX_KHR;
+			}
+		}
+		if( std::find( begin( present_modes ), end( present_modes ), VK_PRESENT_MODE_FIFO_KHR ) != end( present_modes ) )
+		{
+			return VK_PRESENT_MODE_FIFO_KHR;
+		}
+		return static_cast<VkPresentModeKHR>( -1 );
+	}
+}
+
+Tr2PrimaryRenderContextAL::FrameData::FrameData()
+	:commandBuffer( VK_NULL_HANDLE ),
+	imageAvailableSemaphore( VK_NULL_HANDLE ),
+	finishedRenderingSemaphore( VK_NULL_HANDLE ),
+	fence( VK_NULL_HANDLE )
+{
+}
+
+
+Tr2PrimaryRenderContextAL::Tr2PrimaryRenderContextAL()
+	:m_events( nullptr ),
+	m_device( VK_NULL_HANDLE ),
+	m_physicalDevice( VK_NULL_HANDLE ),
+	m_graphicsQueue( VK_NULL_HANDLE ),
+	m_presentQueue( VK_NULL_HANDLE ),
+	m_surface( VK_NULL_HANDLE ),
+	m_swapChain( VK_NULL_HANDLE ),
+	m_commandPool( VK_NULL_HANDLE ),
+	m_currentImage( 0 ),
+	m_zeroBuffer( VK_NULL_HANDLE ),
+	m_zeroBufferMemory( VK_NULL_HANDLE )
+{
+	m_defaultBackBuffer.m_texture = std::make_shared<TrinityALImpl::Tr2TextureAL>();
+}
+
+Tr2PrimaryRenderContextAL::~Tr2PrimaryRenderContextAL()
+{
+	Destroy();
+}
+
+ALResult Tr2PrimaryRenderContextAL::CreateDevice(
+	uint32_t adapter,
+	Tr2WindowHandle  focusWindow,
+	const Tr2PresentParametersAL& presentationParameters )
+{
+	Destroy();
+
+	VkInstance instance;
+	FORWARD_HR( TrinityALImpl::GetVulkanInstance( instance ) );
+	TrinityALImpl::VulkanDeviceInfo physicalDevice;
+	FORWARD_HR( TrinityALImpl::GetPhysicalDevice( adapter, physicalDevice ) );
+
+	const bool isWindowless = ( focusWindow == 0 ) && presentationParameters.software;
+
+	VkDevice device = VK_NULL_HANDLE;
+	ON_BLOCK_EXIT( [=] { if( device != VK_NULL_HANDLE ) vkDestroyDevice( device, nullptr ); } );
+	VkSurfaceKHR surface = VK_NULL_HANDLE;
+	ON_BLOCK_EXIT( [=] { if( surface != VK_NULL_HANDLE ) vkDestroySurfaceKHR( instance, surface, nullptr ); } );
+	VkSwapchainKHR swapChain = VK_NULL_HANDLE;
+	ON_BLOCK_EXIT( [=] { if( swapChain != VK_NULL_HANDLE ) vkDestroySwapchainKHR( device, swapChain, nullptr ); } );
+	std::vector<VkImage> backBuffers;
+
+	uint32_t graphicsQueue = physicalDevice.graphicsQueue;
+	uint32_t presentQueue = graphicsQueue;
+
+	if( !isWindowless )
+	{
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+
+		VkWin32SurfaceCreateInfoKHR surfacecreateInfo = {
+			VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR,
+			nullptr,
+			0,
+			GetModuleHandle( nullptr ),
+			focusWindow
+		};
+
+		CR_RETURN_HR( Vk2Al( vkCreateWin32SurfaceKHR( instance, &surfacecreateInfo, nullptr, &surface ) ) );
+#else
+		static_assert( false, "Define swapchain creation for this platform here" );
+#endif
+		if( !FindPresentableQueues( physicalDevice.device, surface, graphicsQueue, presentQueue ) )
+		{
+			CCP_AL_LOGERR( "Could not find graphics queues for the selected device" );
+			return E_FAIL;
+		}
+	}
+
+	std::vector<VkDeviceQueueCreateInfo> queueCreateInfos;
+	std::vector<float> queuePriorities;
+	queuePriorities.push_back( 1 );
+
+	VkDeviceQueueCreateInfo graphicsQueueInfo = {
+		VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+		nullptr,
+		0,
+		graphicsQueue,
+		uint32_t( queuePriorities.size() ),
+		&queuePriorities[0]
+	};
+	queueCreateInfos.push_back( graphicsQueueInfo );
+	if( graphicsQueue != presentQueue )
+	{
+		VkDeviceQueueCreateInfo presentQueueInfo = {
+			VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+			nullptr,
+			0,
+			presentQueue,
+			uint32_t( queuePriorities.size() ),
+			&queuePriorities[0]
+		};
+		queueCreateInfos.push_back( presentQueueInfo );
+	}
+
+	const char* extensions[] = {
+		VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+		VK_KHR_MAINTENANCE1_EXTENSION_NAME
+	};
+
+	VkDeviceCreateInfo device_create_info = {
+		VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+		nullptr,
+		0,
+		uint32_t( queueCreateInfos.size() ),
+		&queueCreateInfos[0],
+		0,
+		nullptr,
+		_countof( extensions ),
+		extensions,
+		nullptr
+	};
+
+	CR_RETURN_HR( Vk2Al( vkCreateDevice( physicalDevice.device, &device_create_info, nullptr, &device ) ) );
+
+	if( !isWindowless )
+	{
+		VkSurfaceCapabilitiesKHR surfaceCapabilities;
+		CR_RETURN_HR( Vk2Al( vkGetPhysicalDeviceSurfaceCapabilitiesKHR( physicalDevice.device, surface, &surfaceCapabilities ) ) );
+
+		std::vector<VkSurfaceFormatKHR> surfaceFormats;
+		FORWARD_HR( TrinityALImpl::QueryArrayNotEmpty( &vkGetPhysicalDeviceSurfaceFormatsKHR, physicalDevice.device, surface, surfaceFormats ) );
+
+		std::vector<VkPresentModeKHR> presentModes;
+		FORWARD_HR( TrinityALImpl::QueryArrayNotEmpty( &vkGetPhysicalDeviceSurfacePresentModesKHR, physicalDevice.device, surface, presentModes ) );
+
+		uint32_t desired_number_of_images = GetSwapChainNumImages( surfaceCapabilities );
+		VkSurfaceFormatKHR desired_format = GetSwapChainFormat( surfaceFormats );
+		VkExtent2D desired_extent = { presentationParameters.mode.width, presentationParameters.mode.height };
+		VkImageUsageFlags desired_usage = GetSwapChainUsageFlags( surfaceCapabilities );
+		VkSurfaceTransformFlagBitsKHR desired_transform = GetSwapChainTransform( surfaceCapabilities );
+		VkPresentModeKHR desired_present_mode = GetSwapChainPresentMode( presentationParameters.presentInterval, presentModes );
+
+		if( static_cast<int>( desired_usage ) == -1 ) {
+			return E_FAIL;
+		}
+		if( static_cast<int>( desired_present_mode ) == -1 ) {
+			return E_FAIL;
+		}
+
+		VkSwapchainCreateInfoKHR swapChainCreateInfo = {
+			VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
+			nullptr,
+			0,
+			surface,
+			desired_number_of_images,
+			desired_format.format,
+			desired_format.colorSpace,
+			desired_extent,
+			1,
+			desired_usage,
+			VK_SHARING_MODE_EXCLUSIVE,
+			0,
+			nullptr,
+			desired_transform,
+			VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+			desired_present_mode,
+			VK_TRUE,
+			VK_NULL_HANDLE
+		};
+
+		CR_RETURN_HR( Vk2Al( vkCreateSwapchainKHR( device, &swapChainCreateInfo, nullptr, &swapChain ) ) );
+
+		VkSemaphoreCreateInfo semaphoreInfo = {
+			VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+			nullptr,
+			0
+		};
+
+		CR_RETURN_HR( TrinityALImpl::QueryArray( &vkGetSwapchainImagesKHR, device, swapChain, backBuffers ) );
+	}
+
+
+	VkCommandPoolCreateInfo cmd_pool_create_info = {
+		VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+		nullptr,
+		VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT | VK_COMMAND_POOL_CREATE_TRANSIENT_BIT,
+		presentQueue
+	};
+
+	VkCommandPool commandPool = VK_NULL_HANDLE;
+	ON_BLOCK_EXIT( [=] {if( commandPool != VK_NULL_HANDLE ) vkDestroyCommandPool( device, commandPool, nullptr ); } );
+	CR_RETURN_HR( Vk2Al( vkCreateCommandPool( device, &cmd_pool_create_info, nullptr, &commandPool ) ) );
+
+	FrameData frameData[VIRTUAL_FRAMES];
+
+	for( size_t i = 0; i < VIRTUAL_FRAMES; ++i )
+	{
+		VkCommandBufferAllocateInfo cmd_buffer_allocate_info = {
+			VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+			nullptr,
+			commandPool,
+			VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+			1
+		};
+		CR_RETURN_HR( Vk2Al( vkAllocateCommandBuffers( device, &cmd_buffer_allocate_info, &frameData[i].commandBuffer ) ) );
+		if( !isWindowless )
+		{
+			VkSemaphoreCreateInfo semaphoreInfo = {
+				VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+				nullptr,
+				0
+			};
+
+			CR_RETURN_HR( Vk2Al( vkCreateSemaphore( device, &semaphoreInfo, nullptr, &frameData[i].imageAvailableSemaphore ) ) );
+			CR_RETURN_HR( Vk2Al( vkCreateSemaphore( device, &semaphoreInfo, nullptr, &frameData[i].finishedRenderingSemaphore ) ) );
+		}
+		else
+		{
+			frameData[i].imageAvailableSemaphore = VK_NULL_HANDLE;
+			frameData[i].finishedRenderingSemaphore = VK_NULL_HANDLE;
+		}
+
+		VkFenceCreateInfo fenceCreateInfo = {
+			VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+			nullptr,
+			VK_FENCE_CREATE_SIGNALED_BIT
+		};
+
+		CR_RETURN_HR( Vk2Al( vkCreateFence( device, &fenceCreateInfo, nullptr, &frameData[i].fence ) ) );
+	}
+
+	vkGetDeviceQueue( device, graphicsQueue, 0, &m_graphicsQueue );
+	vkGetDeviceQueue( device, presentQueue, 0, &m_presentQueue );
+
+	m_device = device;
+	m_physicalDevice = physicalDevice.device;
+	m_physicalDeviceProperties = physicalDevice.properties;
+	m_surface = surface;
+	m_swapChain = swapChain;
+	for( size_t i = 0; i < VIRTUAL_FRAMES; ++i )
+	{
+		m_frameData[i] = frameData[i];
+	}
+
+	m_defaultBackBuffer.m_texture->AssignFromSwapChainVulkan( backBuffers, presentationParameters.mode, *this );
+
+	m_commandPool = commandPool;
+	m_frameIndex = 0;
+
+	device = VK_NULL_HANDLE;
+	surface = VK_NULL_HANDLE;
+	swapChain = VK_NULL_HANDLE;
+	backBuffers.clear();
+	commandPool = VK_NULL_HANDLE;
+
+	m_owner = this;
+
+	BeginFrame();
+
+	{
+		TrinityALImpl::CreateBuffer( m_zeroBuffer, m_zeroBufferMemory, 4, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, *this );
+	}
+
+	if( m_events )
+	{
+		m_events->OnContextCreated( *this );
+	}
+
+	return S_OK;
+}
+
+void Tr2PrimaryRenderContextAL::Destroy()
+{
+	Tr2RenderContextAL::Destroy();
+
+	m_samplerStateFactory.Clear();
+
+	if( m_device != VK_NULL_HANDLE )
+	{
+		vkDeviceWaitIdle( m_device );
+	}
+
+	for( auto it = begin( m_pipelines ); it != end( m_pipelines ); ++it )
+	{
+		vkDestroyPipeline( m_device, it->second, nullptr );
+	}
+	m_pipelines.clear();
+
+	for( auto it = begin( m_renderPasses ); it != end( m_renderPasses ); ++it )
+	{
+		vkDestroyRenderPass( m_device, it->second, nullptr );
+	}
+	m_renderPasses.clear();
+
+	m_defaultBackBuffer.m_texture->Destroy();
+
+	if( m_zeroBuffer )
+	{
+		vkDestroyBuffer( m_device, m_zeroBuffer, nullptr );
+		m_zeroBuffer = VK_NULL_HANDLE;
+		vkFreeMemory( m_device, m_zeroBufferMemory, nullptr );
+		m_zeroBufferMemory = VK_NULL_HANDLE;
+	}
+	for( size_t i = 0; i < VIRTUAL_FRAMES; ++i )
+	{
+		if( m_frameData[i].commandBuffer != VK_NULL_HANDLE )
+		{
+			vkFreeCommandBuffers( m_device, m_commandPool, 1, &m_frameData[i].commandBuffer );
+			m_frameData[i].commandBuffer = VK_NULL_HANDLE;
+		}
+		if( m_frameData[i].fence != VK_NULL_HANDLE )
+		{
+			vkDestroyFence( m_device, m_frameData[i].fence, nullptr );
+			m_frameData[i].fence = VK_NULL_HANDLE;
+		}
+		if( m_frameData[i].finishedRenderingSemaphore != VK_NULL_HANDLE )
+		{
+			vkDestroySemaphore( m_device, m_frameData[i].finishedRenderingSemaphore, nullptr );
+			m_frameData[i].finishedRenderingSemaphore = VK_NULL_HANDLE;
+		}
+		if( m_frameData[i].imageAvailableSemaphore != VK_NULL_HANDLE )
+		{
+			vkDestroySemaphore( m_device, m_frameData[i].imageAvailableSemaphore, nullptr );
+			m_frameData[i].imageAvailableSemaphore = VK_NULL_HANDLE;
+		}
+
+		for( auto it = begin( m_frameData[i].pendingDestroys ); it != end( m_frameData[i].pendingDestroys ); ++it )
+		{
+			( *it->destroyFunction )( m_device, it->object, nullptr );
+		}
+		m_frameData[i].pendingDestroys.clear();
+	}
+
+	if( m_commandPool != VK_NULL_HANDLE )
+	{
+		vkDestroyCommandPool( m_device, m_commandPool, nullptr );
+		m_commandPool = VK_NULL_HANDLE;
+	}
+
+	if( m_swapChain != VK_NULL_HANDLE )
+	{
+		vkDestroySwapchainKHR( m_device, m_swapChain, nullptr );
+		m_swapChain = VK_NULL_HANDLE;
+	}
+	if( m_surface != VK_NULL_HANDLE )
+	{
+		VkInstance instance;
+		TrinityALImpl::GetVulkanInstance( instance );
+		vkDestroySurfaceKHR( instance, m_surface, nullptr );
+		m_surface = VK_NULL_HANDLE;
+	}
+	if( m_device != VK_NULL_HANDLE )
+	{
+		vkDestroyDevice( m_device, nullptr );
+		m_device = VK_NULL_HANDLE;
+	}
+	m_graphicsQueue = VK_NULL_HANDLE;
+	m_presentQueue = VK_NULL_HANDLE;
+	m_physicalDevice = VK_NULL_HANDLE;
+}
+
+bool Tr2PrimaryRenderContextAL::IsValid() const
+{
+	return m_device != VK_NULL_HANDLE;
+}
+
+ALResult Tr2PrimaryRenderContextAL::Present()
+{
+	if( !IsValid() )
+	{
+		return E_INVALIDCALL;
+	}
+
+	if( m_renderPass )
+	{
+		vkCmdEndRenderPass( m_commandBuffer );
+		m_renderPass = VK_NULL_HANDLE;
+	}
+
+	VkImageSubresourceRange subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+	VkImageMemoryBarrier barrier = {
+		VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+		nullptr,
+		VK_ACCESS_TRANSFER_WRITE_BIT,
+		VK_ACCESS_MEMORY_READ_BIT,
+		VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+		VK_QUEUE_FAMILY_IGNORED,
+		VK_QUEUE_FAMILY_IGNORED,
+		m_defaultBackBuffer.m_texture->GetImageVulkan(),
+		subresourceRange
+	};
+	vkCmdPipelineBarrier( m_commandBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr, 0, nullptr, 1, &barrier );
+
+	CR_RETURN_HR( Vk2Al( vkEndCommandBuffer( m_commandBuffer ) ) );
+
+	VkPipelineStageFlags waitMask = VK_PIPELINE_STAGE_TRANSFER_BIT;
+	VkSubmitInfo submitInfo = {
+		VK_STRUCTURE_TYPE_SUBMIT_INFO,
+		nullptr,
+		1,
+		&m_frameData[m_frameIndex].imageAvailableSemaphore,
+		&waitMask,
+		1,
+		&m_commandBuffer,
+		1,
+		&m_frameData[m_frameIndex].finishedRenderingSemaphore
+	};
+	CR_RETURN_HR( Vk2Al( vkQueueSubmit( m_presentQueue, 1, &submitInfo, m_frameData[m_frameIndex].fence ) ) );
+
+	VkPresentInfoKHR presentInfo = {
+		VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
+		nullptr,
+		1,
+		&m_frameData[m_frameIndex].finishedRenderingSemaphore,
+		1,
+		&m_swapChain,
+		&m_currentImage,
+		nullptr
+	};
+	CR_RETURN_HR( Vk2Al( vkQueuePresentKHR( m_presentQueue, &presentInfo ) ) );
+
+	FORWARD_HR( BeginFrame() );
+
+	return S_OK;
+}
+
+ALResult Tr2PrimaryRenderContextAL::BeginFrame()
+{
+
+	m_frameIndex = ( m_frameIndex + 1 ) % VIRTUAL_FRAMES;
+	CR( Vk2Al( vkWaitForFences( m_device, 1, &m_frameData[m_frameIndex].fence, VK_FALSE, 1000000000 ) ) );
+	vkResetFences( m_device, 1, &m_frameData[m_frameIndex].fence );
+
+	for( auto it = begin( m_frameData[m_frameIndex].pendingDestroys ); it != end( m_frameData[m_frameIndex].pendingDestroys ); ++it )
+	{
+		( *it->destroyFunction )( m_device, it->object, nullptr );
+	}
+	m_frameData[m_frameIndex].pendingDestroys.clear();
+
+
+	CR_RETURN_HR( Vk2Al( vkAcquireNextImageKHR( m_device, m_swapChain, UINT64_MAX, m_frameData[m_frameIndex].imageAvailableSemaphore, VK_NULL_HANDLE, &m_currentImage ) ) );
+	m_defaultBackBuffer.m_texture->SetCurrentImageVulkan( m_currentImage );
+	m_commandBuffer = m_frameData[m_frameIndex].commandBuffer;
+
+	VkCommandBufferBeginInfo cmd_buffer_begin_info = {
+		VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+		nullptr,
+		VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+		nullptr
+	};
+
+	CR_RETURN_HR( Vk2Al( vkBeginCommandBuffer( m_commandBuffer, &cmd_buffer_begin_info ) ) );
+
+	VkImageSubresourceRange subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+	VkImageMemoryBarrier barrier = {
+		VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+		nullptr,
+		VK_ACCESS_MEMORY_READ_BIT,
+		VK_ACCESS_TRANSFER_WRITE_BIT,
+		VK_IMAGE_LAYOUT_UNDEFINED,
+		VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		VK_QUEUE_FAMILY_IGNORED,
+		VK_QUEUE_FAMILY_IGNORED,
+		m_defaultBackBuffer.m_texture->GetImageVulkan(),
+		subresourceRange
+	};
+	vkCmdPipelineBarrier( m_commandBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &barrier );
+
+	SetRenderTarget( m_defaultBackBuffer );
+
+	return S_OK;
+}
+
+VkBuffer Tr2PrimaryRenderContextAL::GetZeroBufferVulkan() const
+{
+	return m_zeroBuffer;
+}
+#endif

--- a/trinityal/vulkan/Tr2PrimaryRenderContextVulkan.cpp
+++ b/trinityal/vulkan/Tr2PrimaryRenderContextVulkan.cpp
@@ -197,7 +197,8 @@ Tr2PrimaryRenderContextAL::Tr2PrimaryRenderContextAL()
 	m_commandPool( VK_NULL_HANDLE ),
 	m_currentImage( 0 ),
 	m_zeroBuffer( VK_NULL_HANDLE ),
-	m_zeroBufferMemory( VK_NULL_HANDLE )
+	m_zeroBufferMemory( VK_NULL_HANDLE ),
+	m_frameIndex( 0 )
 {
 	m_defaultBackBuffer.m_texture = std::make_shared<TrinityALImpl::Tr2TextureAL>();
 }

--- a/trinityal/vulkan/Tr2PrimaryRenderContextVulkan.h
+++ b/trinityal/vulkan/Tr2PrimaryRenderContextVulkan.h
@@ -1,0 +1,141 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   February 2019
+//    Copyright: CCP 2019
+//
+
+#pragma once
+
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "../Tr2MemoryCounterAL.h"
+#include "../include/Tr2RenderContextAL.h"
+#include "../include/Tr2CapsAL.h"
+#include "../include/Tr2SamplerStateAL.h"
+#include "../include/Tr2TextureAL.h"
+
+
+struct Tr2PresentParametersAL;
+
+class Tr2PrimaryRenderContextAL : public Tr2RenderContextAL
+{
+public:
+	Tr2PrimaryRenderContextAL();
+	~Tr2PrimaryRenderContextAL();
+
+	ALResult CreateDevice( uint32_t adapter, Tr2WindowHandle focusWindow, const Tr2PresentParametersAL& presentationParameters );
+	void Destroy();
+
+	ALResult SetPresentParameters( unsigned adapter, const Tr2PresentParametersAL& pPresentationParameters )
+	{
+		return E_NOTIMPL;
+	}
+
+	const Tr2CapsAL& GetCaps() const
+	{
+		return m_caps;
+	}
+		
+	ALResult Present();
+
+	bool IsValid() const;
+
+	Tr2RenderContextEnum::PixelFormat GetBackBufferFormat() const
+	{
+		return Tr2RenderContextEnum::PIXEL_FORMAT_UNKNOWN;
+	}
+	
+	static const uint32_t SHADER_TYPE_MASK = 
+		( 1 << Tr2RenderContextEnum::VERTEX_SHADER ) |
+		( 1 << Tr2RenderContextEnum::PIXEL_SHADER ) |
+		( 1 << Tr2RenderContextEnum::COMPUTE_SHADER ) |
+		( 1 << Tr2RenderContextEnum::GEOMETRY_SHADER ) |
+		( 1 << Tr2RenderContextEnum::HULL_SHADER ) |
+		( 1 << Tr2RenderContextEnum::DOMAIN_SHADER );
+
+	template <typename T>
+	void DestroyLaterVulkan( T object, void( VKAPI_CALL *destroyFunction )( VkDevice, T, const VkAllocationCallbacks* ) )
+	{
+		if( !object )
+		{
+			return;
+		}
+		PendingDestroy pd = { (VkBuffer)object, (DestroyFunction)destroyFunction };
+		m_frameData[m_frameIndex].pendingDestroys.push_back( pd );
+	}
+
+	template <typename T>
+	void DestroyLaterVulkan( const std::vector<T> objects, void( VKAPI_CALL *destroyFunction )( VkDevice, T, const VkAllocationCallbacks* ) )
+	{
+		for( auto it = begin( objects ); it != end( objects ); ++it )
+		{
+			this->DestroyLaterVulkan( *it, destroyFunction );
+		}
+	}
+
+	VkBuffer GetZeroBufferVulkan() const;
+public:
+	Tr2TextureAL m_defaultBackBuffer;
+		
+	ITr2RenderContextEvents* m_events;
+
+public:
+	TrinityALImpl::Tr2SamplerStateALFactory m_samplerStateFactory;
+
+	Tr2TextureAL&			GetDefaultBackBuffer()
+	{
+		return m_defaultBackBuffer;
+	}
+private:
+	Tr2PrimaryRenderContextAL( const Tr2PrimaryRenderContextAL& ) /* = delete */;
+	Tr2PrimaryRenderContextAL& operator=( const Tr2PrimaryRenderContextAL& ) /* = delete */;
+
+	typedef void( VKAPI_CALL *DestroyFunction )( VkDevice, VkBuffer, const VkAllocationCallbacks* );
+
+	struct PendingDestroy
+	{
+		VkBuffer object;
+		DestroyFunction destroyFunction;
+	};
+
+	struct FrameData 
+	{
+		//VkFramebuffer framebuffer;
+		VkCommandBuffer commandBuffer;
+		VkSemaphore imageAvailableSemaphore;
+		VkSemaphore finishedRenderingSemaphore;
+		VkFence fence;
+		std::vector<PendingDestroy> pendingDestroys;
+
+		FrameData();
+	};
+
+	static const uint32_t VIRTUAL_FRAMES = 3;
+	FrameData m_frameData[VIRTUAL_FRAMES];
+	uint32_t m_frameIndex;
+
+	ALResult BeginFrame();
+
+	Tr2CapsAL m_caps;
+	VkQueue m_graphicsQueue;
+	VkQueue m_presentQueue;
+
+	VkSwapchainKHR m_swapChain;
+	VkSurfaceKHR m_surface;
+	uint32_t m_currentImage;
+
+	VkCommandPool m_commandPool;
+
+	VkBuffer m_zeroBuffer;
+	VkDeviceMemory m_zeroBufferMemory;
+public:
+	VkDevice m_device;
+	VkPhysicalDevice m_physicalDevice;
+	VkPhysicalDeviceProperties m_physicalDeviceProperties;
+
+	std::map<unsigned, VkRenderPass> m_renderPasses;
+	std::map<unsigned, VkPipeline> m_pipelines;
+};
+
+#endif

--- a/trinityal/vulkan/Tr2RenderContextVulkan.cpp
+++ b/trinityal/vulkan/Tr2RenderContextVulkan.cpp
@@ -1,0 +1,628 @@
+#include "StdAfx.h"
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "Tr2RenderContextVulkan.h"
+#include "Tr2BufferALVulkan.h"
+#include "Tr2ShaderProgramALVulkan.h"
+#include "Tr2PrimaryRenderContextVulkan.h"
+#include "Tr2ResourceSetALVulkan.h"
+#include "Tr2VertexLayoutALVulkan.h"
+#include "Tr2TextureALVulkan.h"
+#include "VkResult.h"
+
+bool g_gatherPipelineStatistics = false;
+
+namespace
+{
+
+	std::pair<uint32_t, uint32_t> s_primitiveToVertexCount[] = {
+		std::make_pair( 0, 0 ),
+		std::make_pair( 3, 0 ),
+		std::make_pair( 1, 2 ),
+		std::make_pair( 0, 0 ),
+		std::make_pair( 2, 0 ),
+		std::make_pair( 1, 1 ),
+		std::make_pair( 1, 0 ),
+	};
+
+}
+
+size_t Tr2RenderContextAL::RenderPassSource::GetHash() const
+{
+	return CcpHashFNV1( this, sizeof( *this ) );
+}
+
+size_t Tr2RenderContextAL::PipelineSource::GetHash() const
+{
+	return CcpHashFNV1( this, sizeof( *this ) );
+}
+
+Tr2RenderContextAL::Tr2RenderContextAL() throw( )
+	:m_dirtyPso( true ),
+	m_owner( nullptr ),
+	m_renderPass( 0 ),
+	m_primitiveToVertexCount( 0, 0 )
+{
+	memset( &m_pipelineSource, 0, sizeof( m_pipelineSource ) );
+
+	m_pipelineSource.m_depthStencilState.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+	m_pipelineSource.m_rasterizationState.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+	m_pipelineSource.m_rasterizationState.lineWidth = 1;
+
+	VkPipelineColorBlendAttachmentState defaultAttachment = {
+		VK_FALSE,                                                     // VkBool32                                       blendEnable
+		VK_BLEND_FACTOR_ONE,                                          // VkBlendFactor                                  srcColorBlendFactor
+		VK_BLEND_FACTOR_ZERO,                                         // VkBlendFactor                                  dstColorBlendFactor
+		VK_BLEND_OP_ADD,                                              // VkBlendOp                                      colorBlendOp
+		VK_BLEND_FACTOR_ONE,                                          // VkBlendFactor                                  srcAlphaBlendFactor
+		VK_BLEND_FACTOR_ZERO,                                         // VkBlendFactor                                  dstAlphaBlendFactor
+		VK_BLEND_OP_ADD,                                              // VkBlendOp                                      alphaBlendOp
+		VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |         // VkColorComponentFlags                          colorWriteMask
+		VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT
+	};
+
+	for( uint32_t i = 0; i < _countof( m_pipelineSource.m_attachmentBlend ); ++i )
+	{
+		m_pipelineSource.m_attachmentBlend[i] = defaultAttachment;
+	}
+
+	VkPipelineColorBlendStateCreateInfo defaultColorBlend = {
+		VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,     // VkStructureType                                sType
+		nullptr,                                                      // const void                                    *pNext
+		0,                                                            // VkPipelineColorBlendStateCreateFlags           flags
+		VK_FALSE,                                                     // VkBool32                                       logicOpEnable
+		VK_LOGIC_OP_COPY,                                             // VkLogicOp                                      logicOp
+		1,                                                            // uint32_t                                       attachmentCount
+		m_pipelineSource.m_attachmentBlend,                                // const VkPipelineColorBlendAttachmentState     *pAttachments
+		{ 0.0f, 0.0f, 0.0f, 0.0f }                                    // float                                          blendConstants[4]
+	};
+	m_pipelineSource.m_colorBlendState = defaultColorBlend;
+
+}
+
+Tr2RenderContextAL::~Tr2RenderContextAL() throw( )
+{
+	Destroy();
+}
+
+void Tr2RenderContextAL::Destroy() throw( )
+{
+	if( m_framebuffer != VK_NULL_HANDLE )
+	{
+		m_owner->DestroyLaterVulkan( m_framebuffer, vkDestroyFramebuffer );
+		m_framebuffer = VK_NULL_HANDLE;
+	}
+}
+
+bool Tr2RenderContextAL::IsValid() const throw( )
+{
+	return m_owner != nullptr;
+}
+
+ALResult Tr2RenderContextAL::BeginScene() throw( )
+{
+	return S_OK;
+}
+
+ALResult Tr2RenderContextAL::EndScene()
+{
+	return S_OK;
+}
+
+ALResult Tr2RenderContextAL::Clear(
+	uint32_t clearFlags,
+	uint32_t color,
+	float depth,
+	uint32_t stencil,
+	uint32_t slot ) throw( )
+{
+	if( clearFlags & Tr2RenderContextEnum::CLEARFLAGS_TARGET )
+	{
+		if( m_boundRenderTargets[slot].IsValid() )
+		{
+			float f = 1.0f / 255.0f;
+			VkClearColorValue clearColor = {
+				{
+					f * (float)(uint8_t)( color >> 16 ),
+					f * (float)(uint8_t)( color >> 8 ),
+					f * (float)(uint8_t)( color >> 0 ),
+					f * (float)(uint8_t)( color >> 24 )
+				} 
+			};
+
+			if( m_renderPass )
+			{
+				vkCmdEndRenderPass( m_commandBuffer );
+				m_renderPass = VK_NULL_HANDLE;
+
+				VkImageSubresourceRange subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+				VkImageMemoryBarrier barrier = {
+					VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+					nullptr,
+					VK_ACCESS_TRANSFER_WRITE_BIT,
+					VK_ACCESS_MEMORY_READ_BIT,
+					VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+					VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+					VK_QUEUE_FAMILY_IGNORED,
+					VK_QUEUE_FAMILY_IGNORED,
+					m_boundRenderTargets[slot].m_texture->GetImageVulkan(),
+					subresourceRange
+				};
+				vkCmdPipelineBarrier( m_commandBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr, 0, nullptr, 1, &barrier );
+			}
+
+			VkImageSubresourceRange subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+			vkCmdClearColorImage( m_commandBuffer, m_boundRenderTargets[slot].m_texture->GetImageVulkan(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clearColor, 1, &subresourceRange );
+
+			m_dirtyPass = true;
+		}
+		else
+		{
+			return E_INVALIDCALL;
+		}
+	}
+	if( clearFlags & Tr2RenderContextEnum::CLEARFLAGS_ZBUFFER )
+	{
+		return E_NOTIMPL;
+	}
+	if( clearFlags & Tr2RenderContextEnum::CLEARFLAGS_STENCIL )
+	{
+		return E_NOTIMPL;
+	}
+
+	return S_OK;
+}
+
+ALResult Tr2RenderContextAL::SetStreamSource( uint32_t stream, const Tr2BufferAL & buffer, uint32_t offset, uint32_t stride ) throw( )
+{
+	VkDeviceSize deviceOffset = offset;
+	if( !buffer.IsValid() )
+	{
+		auto buf = m_owner->GetZeroBufferVulkan();
+		vkCmdBindVertexBuffers( m_commandBuffer, stream, 1, &buf, &deviceOffset );
+		return S_OK;
+	}
+	m_pipelineSource.m_streams[stream].stride = stride;
+	vkCmdBindVertexBuffers( m_commandBuffer, stream, 1, &buffer.m_buffer->m_buffer, &deviceOffset );
+	return S_OK;
+}
+
+ALResult Tr2RenderContextAL::SetIndices( const Tr2BufferAL & buffer ) throw( )
+{
+	if( !buffer.IsValid() )
+	{
+		vkCmdBindIndexBuffer( m_commandBuffer, m_owner->GetZeroBufferVulkan(), 0, VK_INDEX_TYPE_UINT16 );
+		return S_OK;
+	}
+	vkCmdBindIndexBuffer( m_commandBuffer, buffer.m_buffer->m_buffer, 0, buffer.GetDesc().stride == 4 ?  VK_INDEX_TYPE_UINT32 : VK_INDEX_TYPE_UINT16 );
+	return S_OK;
+}
+
+
+ALResult Tr2RenderContextAL::SetVertexLayout( const Tr2VertexLayoutAL& layout ) throw( )
+{
+	if( !( m_pipelineSource.m_layout == layout ) )
+	{
+		m_pipelineSource.m_layout = layout;
+		m_dirtyPso = true;
+	}
+	return S_OK;
+}
+
+namespace
+{
+	VkPrimitiveTopology s_topologyMap[] = {
+		VK_PRIMITIVE_TOPOLOGY_MAX_ENUM,
+		VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
+		VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP,
+		VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN,
+		VK_PRIMITIVE_TOPOLOGY_LINE_LIST,
+		VK_PRIMITIVE_TOPOLOGY_LINE_STRIP,
+		VK_PRIMITIVE_TOPOLOGY_POINT_LIST,
+	};
+}
+
+ALResult Tr2RenderContextAL::SetTopology( Tr2RenderContextEnum::Topology topology ) throw( )
+{
+	auto top = s_topologyMap[topology];
+	if( top != m_pipelineSource.m_topology )
+	{
+		m_primitiveToVertexCount = s_primitiveToVertexCount[topology];
+		m_pipelineSource.m_topology = top;
+		m_dirtyPso = true;
+	}
+	return S_OK;
+}
+
+ALResult Tr2RenderContextAL::SetShaderProgram( const Tr2ShaderProgramAL& shader ) throw( )
+{
+	if( !( m_pipelineSource.m_shaderProgram == shader ) )
+	{
+		m_pipelineSource.m_shaderProgram = shader;
+		m_dirtyPso = true;
+	}
+	return S_OK;
+}
+
+ALResult Tr2RenderContextAL::SetResourceSet( const Tr2ResourceSetAL& resourceSet ) throw( )
+{
+	m_resourceSet = resourceSet;
+	return S_OK;
+}
+
+
+ALResult Tr2RenderContextAL::SetRenderState( Tr2RenderContextEnum::RenderState state, uint32_t value ) throw( )
+{
+	switch( state )
+	{
+	case Tr2RenderContextEnum::RS_ZENABLE:
+		m_pipelineSource.m_depthStencilState.depthTestEnable = value != 0;
+		m_dirtyPso = true;
+		return S_OK;
+	case Tr2RenderContextEnum::RS_CULLMODE:
+		m_pipelineSource.m_rasterizationState.cullMode = value - 1;
+		m_dirtyPso = true;
+		return S_OK;
+	case Tr2RenderContextEnum::RS_ALPHABLENDENABLE:
+		m_pipelineSource.m_attachmentBlend[0].blendEnable = value != 0;
+		m_pipelineSource.m_attachmentBlend[1].blendEnable = value != 0;
+		m_pipelineSource.m_attachmentBlend[2].blendEnable = value != 0;
+		m_pipelineSource.m_attachmentBlend[3].blendEnable = value != 0;
+		m_dirtyPso = true;
+		return S_OK;
+	default:
+		return E_NOTIMPL;
+	}
+}
+
+ALResult Tr2RenderContextAL::SetRenderStates( const uint32_t* stateValuePairs, uint32_t count ) throw( )
+{
+	for( uint32_t i = 0; i < count; ++i )
+	{
+		FORWARD_HR( SetRenderState( Tr2RenderContextEnum::RenderState( *stateValuePairs++ ), *stateValuePairs++ ) );
+	}
+	return S_OK;
+}
+
+ALResult Tr2RenderContextAL::SetRenderTarget( const Tr2TextureAL& renderTarget, uint32_t slot, uint32_t slice ) throw()
+{
+	m_boundRenderTargets[slot] = renderTarget;
+
+	if( renderTarget.IsValid() )
+	{
+		VkAttachmentDescription attachment = {
+			0,
+			renderTarget.m_texture->m_format,
+			VkSampleCountFlagBits( renderTarget.GetMsaaDesc().samples ),
+			VK_ATTACHMENT_LOAD_OP_LOAD,
+			VK_ATTACHMENT_STORE_OP_STORE,
+			VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+			VK_ATTACHMENT_STORE_OP_DONT_CARE,
+			VK_IMAGE_LAYOUT_UNDEFINED,
+			VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		};
+		if( memcmp( &m_renderPassSource.m_rt[slot + 1], &attachment, sizeof( attachment ) ) != 0 )
+		{
+			m_renderPassSource.m_rt[slot + 1] = attachment;
+			m_dirtyPass = true;
+		}
+	}
+	else
+	{
+		VkAttachmentDescription attachment = {
+			0,
+			VK_FORMAT_UNDEFINED,
+			VK_SAMPLE_COUNT_1_BIT,
+			VK_ATTACHMENT_LOAD_OP_LOAD,
+			VK_ATTACHMENT_STORE_OP_STORE,
+			VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+			VK_ATTACHMENT_STORE_OP_DONT_CARE,
+			VK_IMAGE_LAYOUT_UNDEFINED,
+			VK_IMAGE_LAYOUT_UNDEFINED,
+		};
+		if( memcmp( &m_renderPassSource.m_rt[slot + 1], &attachment, sizeof( attachment ) ) != 0 )
+		{
+			m_renderPassSource.m_rt[slot + 1] = attachment;
+			m_dirtyPass = true;
+		}
+	}
+	return S_OK;
+}
+
+ALResult Tr2RenderContextAL::DrawIndexedPrimitive(
+	uint32_t numVertices,
+	uint32_t startIndex,
+	uint32_t primitiveCount,
+	uint32_t minimumIndex ) throw( )
+{
+	SetPipeline();
+
+	vkCmdDrawIndexed( m_commandBuffer, m_primitiveToVertexCount.first * primitiveCount + m_primitiveToVertexCount.second, 1, 0, 0, 0 );
+	return S_OK;
+}
+
+ALResult Tr2RenderContextAL::DrawPrimitive( uint32_t startVertex, uint32_t primitiveCount ) throw( )
+{
+	SetPipeline();
+
+	vkCmdDraw( m_commandBuffer, m_primitiveToVertexCount.first * primitiveCount + m_primitiveToVertexCount.second, 1, 0, 0 );
+	return S_OK;
+}
+
+ALResult Tr2RenderContextAL::SetPass()
+{
+	if( !m_dirtyPass )
+	{
+		return S_OK;
+	}
+
+	auto hash = m_renderPassSource.GetHash();
+	auto found = m_owner->m_renderPasses.find( hash );
+	if( found == m_owner->m_renderPasses.end() )
+	{
+		FORWARD_HR( CreateRenderPass( m_renderPass ) );
+		m_owner->m_renderPasses[hash] = m_renderPass;
+	}
+	else
+	{
+		m_renderPass = found->second;
+	}
+	UpdateFramebuffer();
+
+	VkRenderPassBeginInfo render_pass_begin_info = {
+		VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+		nullptr,
+		m_renderPass,
+		m_framebuffer,
+		{ { 0, 0 }, { m_boundRenderTargets[0].GetWidth(), m_boundRenderTargets[0].GetHeight() } },
+		0,
+		nullptr
+	};
+
+	vkCmdBeginRenderPass( m_commandBuffer, &render_pass_begin_info, VK_SUBPASS_CONTENTS_INLINE );
+
+	VkViewport viewport = {
+		0.0f,
+		float( m_boundRenderTargets[0].GetHeight() ),
+		float( m_boundRenderTargets[0].GetWidth() ),
+		-float( m_boundRenderTargets[0].GetHeight() ),
+		0.0f,
+		1.0f
+	};
+
+	VkRect2D scissor = {
+		{ 0, 0 },
+		{ m_boundRenderTargets[0].GetWidth(), m_boundRenderTargets[0].GetHeight() }
+	};
+
+	vkCmdSetViewport( m_commandBuffer, 0, 1, &viewport );
+	vkCmdSetScissor( m_commandBuffer, 0, 1, &scissor );
+
+	m_dirtyPass = false;
+	m_dirtyPso = true;
+	return S_OK;
+}
+
+ALResult Tr2RenderContextAL::CreateRenderPass( VkRenderPass& renderPass )
+{
+	VkAttachmentDescription attachments[5];
+	VkAttachmentReference ds = { 0xffffffff };
+	VkAttachmentReference rts[4];
+
+	uint32_t count = 0;
+	uint32_t rtCount = 0;
+
+	for( uint32_t i = 0; i < 5; ++i )
+	{
+		if( m_renderPassSource.m_rt[i].format != VK_FORMAT_UNDEFINED )
+		{
+			if( i == 0 )
+			{
+				ds.attachment = count;
+			}
+			else
+			{
+				rts[i - 1].attachment = count;
+				rts[i - 1].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+				rtCount = i;
+			}
+			attachments[count++] = m_renderPassSource.m_rt[i];
+		}
+	}
+
+	VkSubpassDescription subpass = {
+		0,
+		VK_PIPELINE_BIND_POINT_GRAPHICS,
+		0,
+		nullptr,
+		rtCount,
+		rts,
+		nullptr,
+		ds.attachment != 0xffffffff ? &ds : nullptr,
+		0,
+		nullptr
+	};
+
+	VkRenderPassCreateInfo renderPassInfo = {
+		VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+		nullptr,
+		0,
+		count,
+		attachments,
+		1,
+		&subpass,
+		0,
+		nullptr
+	};
+
+	return Vk2Al( vkCreateRenderPass( m_owner->m_device, &renderPassInfo, nullptr, &renderPass ) );
+}
+
+void Tr2RenderContextAL::UpdateFramebuffer()
+{
+	if( m_framebuffer != VK_NULL_HANDLE )
+	{
+		m_owner->DestroyLaterVulkan( m_framebuffer, vkDestroyFramebuffer );
+		m_framebuffer = VK_NULL_HANDLE;
+	}
+
+	uint32_t width = m_boundRenderTargets[0].GetWidth();
+	uint32_t height = m_boundRenderTargets[0].GetHeight();
+
+	VkImageView views[4] = {};
+	views[0] = m_boundRenderTargets[0].m_texture->GetImageView();
+
+	VkFramebufferCreateInfo framebufferInfo = {
+		VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+		nullptr,
+		0,
+		m_renderPass,
+		1,
+		views,
+		width,
+		height,
+		1
+	};
+
+	Vk2Al( vkCreateFramebuffer( m_owner->m_device, &framebufferInfo, nullptr, &m_framebuffer ) );
+}
+
+ALResult Tr2RenderContextAL::SetPipeline()
+{
+	if( m_dirtyPass )
+	{
+		SetPass();
+	}
+	if( !m_dirtyPso )
+	{
+		return S_OK;
+	}
+
+	auto hash = m_pipelineSource.GetHash();
+	auto found = m_owner->m_pipelines.find( hash );
+	VkPipeline pipeline;
+	if( found == m_owner->m_pipelines.end() )
+	{
+		FORWARD_HR( CreatePipeline( pipeline ) );
+		m_owner->m_pipelines[hash] = pipeline;
+	}
+	else
+	{
+		pipeline = found->second;
+	}
+	vkCmdBindPipeline( m_commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline );
+
+	if( m_resourceSet.IsValid() && m_resourceSet.m_resourceSet->m_descriptorSet )
+	{
+		vkCmdBindDescriptorSets( 
+			m_commandBuffer, 
+			VK_PIPELINE_BIND_POINT_GRAPHICS, 
+			m_pipelineSource.m_shaderProgram.m_program->m_pipelineLayout, 
+			1, 
+			1,
+			&m_resourceSet.m_resourceSet->m_descriptorSet, 0, nullptr );
+	}
+	return S_OK;
+}
+
+ALResult Tr2RenderContextAL::CreatePipeline( VkPipeline& pipeline )
+{
+	std::vector<VkVertexInputAttributeDescription> layout;
+	m_pipelineSource.m_layout.m_layout->PopulateInputLayoutVulkan( layout, m_pipelineSource.m_shaderProgram.m_program->m_shaderInputs );
+
+	VkPipelineVertexInputStateCreateInfo vertexInput = {
+		VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
+		nullptr,
+		0,
+		m_pipelineSource.m_layout.m_layout->m_streamCount,
+		m_pipelineSource.m_streams,
+		uint32_t( layout.size() ),
+		layout.data()
+	};
+
+	VkPipelineInputAssemblyStateCreateInfo inputAssembly = {
+		VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
+		nullptr,
+		0,
+		m_pipelineSource.m_topology,
+		VK_FALSE
+	};
+
+	VkPipelineViewportStateCreateInfo viewport = {
+		VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
+		nullptr,
+		0,
+		1,
+		nullptr,
+		1,
+		nullptr
+	};
+
+	VkPipelineMultisampleStateCreateInfo msaa = {
+		VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
+		nullptr,
+		0,
+		VK_SAMPLE_COUNT_1_BIT,
+		VK_FALSE,
+		1.0f,
+		nullptr,
+		VK_FALSE,
+		VK_FALSE
+	};
+
+	VkDynamicState dynamicStates[] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR, };
+
+	VkPipelineDynamicStateCreateInfo dynamicInfo = {
+		VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO,
+		nullptr,
+		0,
+		2,
+		dynamicStates
+	};
+
+	VkGraphicsPipelineCreateInfo pipelineCreateInfo = {
+		VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
+		nullptr,
+		0,
+		static_cast<uint32_t>( m_pipelineSource.m_shaderProgram.m_program->m_shaderInfo.size() ),
+		m_pipelineSource.m_shaderProgram.m_program->m_shaderInfo.data(),
+		&vertexInput,
+		&inputAssembly,
+		nullptr,
+		&viewport,
+		&m_pipelineSource.m_rasterizationState,
+		&msaa,
+		nullptr,
+		&m_pipelineSource.m_colorBlendState,
+		&dynamicInfo,
+		m_pipelineSource.m_shaderProgram.m_program->m_pipelineLayout,
+		m_renderPass,
+		0,
+		VK_NULL_HANDLE,
+		-1
+	};
+
+	return Vk2Al( vkCreateGraphicsPipelines( m_owner->m_device, VK_NULL_HANDLE, 1, &pipelineCreateInfo, nullptr, &pipeline ) );
+}
+
+void Tr2RenderContextAL::RenderPassHint( const Tr2ColorAttachment&, const Tr2DepthAttachment& )
+{
+}
+
+void Tr2RenderContextAL::RenderPassHint( const Tr2ColorAttachment&, const Tr2ColorAttachment&, const Tr2DepthAttachment& )
+{
+}
+
+ALResult Tr2RenderContextAL::UseTextures( Tr2GpuUsage::Type, size_t, Tr2TextureAL* )
+{
+	return S_OK;
+}
+
+ALResult Tr2RenderContextAL::UseAccelerationStructure( Tr2RtTopLevelAccelerationStructureAL tlas )
+{
+    return S_OK;
+}
+
+
+#endif

--- a/trinityal/vulkan/Tr2RenderContextVulkan.cpp
+++ b/trinityal/vulkan/Tr2RenderContextVulkan.cpp
@@ -10,6 +10,7 @@
 #include "Tr2VertexLayoutALVulkan.h"
 #include "Tr2TextureALVulkan.h"
 #include "VkResult.h"
+#include "../include/Tr2RtTopLevelAccelerationStructureAL.h"
 
 bool g_gatherPipelineStatistics = false;
 

--- a/trinityal/vulkan/Tr2RenderContextVulkan.cpp
+++ b/trinityal/vulkan/Tr2RenderContextVulkan.cpp
@@ -97,6 +97,15 @@ void Tr2RenderContextAL::Destroy() throw( )
 		m_owner->DestroyLaterVulkan( m_framebuffer, vkDestroyFramebuffer );
 		m_framebuffer = VK_NULL_HANDLE;
 	}
+
+	// Release device resources held by this render context while the device is
+	// still live. m_pipelineSource.m_shaderProgram is a member destroyed by the
+	// base-class destructor, which runs after Tr2PrimaryRenderContextAL::Destroy()
+	// has already vkDestroyDevice'd -- and Tr2ShaderAL::Destroy() destroys its
+	// VkShaderModule directly against m_owner->m_device, so leaving the program
+	// for the destructor means destroying the module against a null device.
+	m_pipelineSource.m_shaderProgram = Tr2ShaderProgramAL();
+	m_resourceSet = Tr2ResourceSetAL();
 }
 
 bool Tr2RenderContextAL::IsValid() const throw( )

--- a/trinityal/vulkan/Tr2RenderContextVulkan.cpp
+++ b/trinityal/vulkan/Tr2RenderContextVulkan.cpp
@@ -9,6 +9,8 @@
 #include "Tr2ResourceSetALVulkan.h"
 #include "Tr2VertexLayoutALVulkan.h"
 #include "Tr2TextureALVulkan.h"
+#include "Tr2ConstantBufferALVulkan.h"
+#include "Tr2ShaderBindingABIVulkan.h"
 #include "VkResult.h"
 #include "../include/Tr2RtTopLevelAccelerationStructureAL.h"
 
@@ -46,9 +48,14 @@ Tr2RenderContextAL::Tr2RenderContextAL() throw( )
 	m_renderPass( 0 ),
 	m_framebuffer( VK_NULL_HANDLE ),
 	m_commandBuffer( VK_NULL_HANDLE ),
+	m_constantPool( VK_NULL_HANDLE ),
+	m_constantSet( VK_NULL_HANDLE ),
+	m_boundConstantLayout( VK_NULL_HANDLE ),
+	m_constantsDirty( false ),
 	m_primitiveToVertexCount( 0, 0 )
 {
 	memset( &m_pipelineSource, 0, sizeof( m_pipelineSource ) );
+	memset( &m_renderPassSource, 0, sizeof( m_renderPassSource ) );
 
 	m_pipelineSource.m_depthStencilState.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
 	m_pipelineSource.m_rasterizationState.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
@@ -106,6 +113,16 @@ void Tr2RenderContextAL::Destroy() throw( )
 	// for the destructor means destroying the module against a null device.
 	m_pipelineSource.m_shaderProgram = Tr2ShaderProgramAL();
 	m_resourceSet = Tr2ResourceSetAL();
+
+	if( m_constantPool != VK_NULL_HANDLE )
+	{
+		m_owner->DestroyLaterVulkan( m_constantPool, vkDestroyDescriptorPool );
+		m_constantPool = VK_NULL_HANDLE;
+	}
+	m_constantSet = VK_NULL_HANDLE;
+	m_boundConstantLayout = VK_NULL_HANDLE;
+	m_constantBuffers.clear();
+	m_constantsDirty = false;
 }
 
 bool Tr2RenderContextAL::IsValid() const throw( )
@@ -252,6 +269,19 @@ ALResult Tr2RenderContextAL::SetShaderProgram( const Tr2ShaderProgramAL& shader 
 {
 	if( !( m_pipelineSource.m_shaderProgram == shader ) )
 	{
+		// The constant descriptor set/pool belong to the old program's layout, which
+		// is destroyed when the program is released (and the driver may reuse the
+		// handle). Invalidate them so the next SetPipeline reallocates against the
+		// new program's layout rather than comparing stale layout handles.
+		if( m_constantPool )
+		{
+			m_owner->DestroyLaterVulkan( m_constantPool, vkDestroyDescriptorPool );
+			m_constantPool = VK_NULL_HANDLE;
+		}
+		m_constantSet = VK_NULL_HANDLE;
+		m_boundConstantLayout = VK_NULL_HANDLE;
+		m_constantsDirty = true;
+
 		m_pipelineSource.m_shaderProgram = shader;
 		m_dirtyPso = true;
 	}
@@ -261,6 +291,27 @@ ALResult Tr2RenderContextAL::SetShaderProgram( const Tr2ShaderProgramAL& shader 
 ALResult Tr2RenderContextAL::SetResourceSet( const Tr2ResourceSetAL& resourceSet ) throw( )
 {
 	m_resourceSet = resourceSet;
+	return S_OK;
+}
+
+ALResult Tr2RenderContextAL::SetConstants( const Tr2ConstantBufferAL& buffer, Tr2RenderContextEnum::ShaderType constantType, uint32_t registerIndex, uint32_t ) throw( )
+{
+	if( !m_owner )
+	{
+		return E_INVALIDCALL;
+	}
+
+	const uint32_t binding = Tr2VulkanBindingABI::BindingNumber( Tr2ShaderRegisterAL::CONSTANT_BUFFER, registerIndex, constantType );
+
+	if( !buffer.IsValid() )
+	{
+		m_constantBuffers.erase( binding );
+	}
+	else
+	{
+		m_constantBuffers[binding] = buffer.m_buffer->GetBufferVulkan();
+	}
+	m_constantsDirty = true;
 	return S_OK;
 }
 
@@ -526,15 +577,101 @@ ALResult Tr2RenderContextAL::SetPipeline()
 	}
 	vkCmdBindPipeline( m_commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline );
 
-	if( m_resourceSet.IsValid() && m_resourceSet.m_resourceSet->m_descriptorSet )
+	auto* program = m_pipelineSource.m_shaderProgram.m_program.get();
+	if( m_resourceSet.IsValid() && m_resourceSet.m_resourceSet->m_descriptorSet && program && program->m_resourceLayout )
 	{
 		vkCmdBindDescriptorSets( 
 			m_commandBuffer, 
 			VK_PIPELINE_BIND_POINT_GRAPHICS, 
-			m_pipelineSource.m_shaderProgram.m_program->m_pipelineLayout, 
+			program->m_pipelineLayout, 
 			1, 
 			1,
 			&m_resourceSet.m_resourceSet->m_descriptorSet, 0, nullptr );
+	}
+
+	// Bind constant buffers at descriptor set 0, if the program declares any and
+	// any were set. The descriptor set is allocated once per layout and re-written
+	// in place when the constants change.
+	{
+		if( program && program->m_constantLayout && !m_constantBuffers.empty() )
+		{
+			if( m_boundConstantLayout != program->m_constantLayout )
+			{
+				m_boundConstantLayout = program->m_constantLayout;
+				if( m_constantPool )
+				{
+					m_owner->DestroyLaterVulkan( m_constantPool, vkDestroyDescriptorPool );
+					m_constantPool = VK_NULL_HANDLE;
+				}
+				m_constantSet = VK_NULL_HANDLE;
+			}
+
+			if( !m_constantSet )
+			{
+				if( !m_constantPool )
+				{
+					VkDescriptorPoolSize poolSize = { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 32 };
+					VkDescriptorPoolCreateInfo poolInfo = {
+						VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+						nullptr,
+						0,
+						1,
+						1,
+						&poolSize
+					};
+					CR_RETURN_HR( Vk2Al( vkCreateDescriptorPool( m_owner->m_device, &poolInfo, nullptr, &m_constantPool ) ) );
+				}
+
+				VkDescriptorSetAllocateInfo allocateInfo = {
+					VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+					nullptr,
+					m_constantPool,
+					1,
+					&program->m_constantLayout
+				};
+				CR_RETURN_HR( Vk2Al( vkAllocateDescriptorSets( m_owner->m_device, &allocateInfo, &m_constantSet ) ) );
+				m_constantsDirty = true;
+			}
+
+			if( m_constantsDirty )
+			{
+				std::vector<VkWriteDescriptorSet> writes;
+				std::vector<VkDescriptorBufferInfo> bufferInfos;
+				writes.reserve( m_constantBuffers.size() );
+				bufferInfos.reserve( m_constantBuffers.size() );
+				for( auto it = begin( m_constantBuffers ); it != end( m_constantBuffers ); ++it )
+				{
+					VkDescriptorBufferInfo bufferInfo = { it->second, 0, VK_WHOLE_SIZE };
+					bufferInfos.push_back( bufferInfo );
+					VkWriteDescriptorSet write = {
+						VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+						nullptr,
+						m_constantSet,
+						it->first,
+						0,
+						1,
+						VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+						nullptr,
+						&bufferInfos.back(),
+						nullptr
+					};
+					writes.push_back( write );
+				}
+				vkUpdateDescriptorSets( m_owner->m_device, uint32_t( writes.size() ), writes.data(), 0, nullptr );
+
+				m_constantsDirty = false;
+			}
+
+			vkCmdBindDescriptorSets(
+				m_commandBuffer,
+				VK_PIPELINE_BIND_POINT_GRAPHICS,
+				program->m_pipelineLayout,
+				0,
+				1,
+				&m_constantSet,
+				0,
+				nullptr );
+		}
 	}
 	return S_OK;
 }

--- a/trinityal/vulkan/Tr2RenderContextVulkan.cpp
+++ b/trinityal/vulkan/Tr2RenderContextVulkan.cpp
@@ -41,8 +41,11 @@ size_t Tr2RenderContextAL::PipelineSource::GetHash() const
 
 Tr2RenderContextAL::Tr2RenderContextAL() throw( )
 	:m_dirtyPso( true ),
+	m_dirtyPass( true ),
 	m_owner( nullptr ),
 	m_renderPass( 0 ),
+	m_framebuffer( VK_NULL_HANDLE ),
+	m_commandBuffer( VK_NULL_HANDLE ),
 	m_primitiveToVertexCount( 0, 0 )
 {
 	memset( &m_pipelineSource, 0, sizeof( m_pipelineSource ) );

--- a/trinityal/vulkan/Tr2RenderContextVulkan.cpp
+++ b/trinityal/vulkan/Tr2RenderContextVulkan.cpp
@@ -52,6 +52,8 @@ Tr2RenderContextAL::Tr2RenderContextAL() throw( )
 	m_constantSet( VK_NULL_HANDLE ),
 	m_boundConstantLayout( VK_NULL_HANDLE ),
 	m_constantsDirty( false ),
+	m_computePipeline( VK_NULL_HANDLE ),
+	m_computePipelineLayout( VK_NULL_HANDLE ),
 	m_primitiveToVertexCount( 0, 0 )
 {
 	memset( &m_pipelineSource, 0, sizeof( m_pipelineSource ) );
@@ -123,6 +125,13 @@ void Tr2RenderContextAL::Destroy() throw( )
 	m_boundConstantLayout = VK_NULL_HANDLE;
 	m_constantBuffers.clear();
 	m_constantsDirty = false;
+
+	if( m_computePipeline )
+	{
+		m_owner->DestroyLaterVulkan( m_computePipeline, vkDestroyPipeline );
+		m_computePipeline = VK_NULL_HANDLE;
+	}
+	m_computePipelineLayout = VK_NULL_HANDLE;
 }
 
 bool Tr2RenderContextAL::IsValid() const throw( )
@@ -589,90 +598,148 @@ ALResult Tr2RenderContextAL::SetPipeline()
 			&m_resourceSet.m_resourceSet->m_descriptorSet, 0, nullptr );
 	}
 
-	// Bind constant buffers at descriptor set 0, if the program declares any and
-	// any were set. The descriptor set is allocated once per layout and re-written
-	// in place when the constants change.
+	FORWARD_HR( BindConstantBuffers( VK_PIPELINE_BIND_POINT_GRAPHICS ) );
+	return S_OK;
+}
+
+ALResult Tr2RenderContextAL::BindConstantBuffers( VkPipelineBindPoint bindPoint )
+{
+	auto* program = m_pipelineSource.m_shaderProgram.m_program.get();
+	if( !program || !program->m_constantLayout || m_constantBuffers.empty() )
 	{
-		if( program && program->m_constantLayout && !m_constantBuffers.empty() )
+		return S_OK;
+	}
+	if( m_boundConstantLayout != program->m_constantLayout )
+	{
+		m_boundConstantLayout = program->m_constantLayout;
+		if( m_constantPool )
 		{
-			if( m_boundConstantLayout != program->m_constantLayout )
-			{
-				m_boundConstantLayout = program->m_constantLayout;
-				if( m_constantPool )
-				{
-					m_owner->DestroyLaterVulkan( m_constantPool, vkDestroyDescriptorPool );
-					m_constantPool = VK_NULL_HANDLE;
-				}
-				m_constantSet = VK_NULL_HANDLE;
-			}
+			m_owner->DestroyLaterVulkan( m_constantPool, vkDestroyDescriptorPool );
+			m_constantPool = VK_NULL_HANDLE;
+		}
+		m_constantSet = VK_NULL_HANDLE;
+	}
 
-			if( !m_constantSet )
-			{
-				if( !m_constantPool )
-				{
-					VkDescriptorPoolSize poolSize = { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 32 };
-					VkDescriptorPoolCreateInfo poolInfo = {
-						VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
-						nullptr,
-						0,
-						1,
-						1,
-						&poolSize
-					};
-					CR_RETURN_HR( Vk2Al( vkCreateDescriptorPool( m_owner->m_device, &poolInfo, nullptr, &m_constantPool ) ) );
-				}
-
-				VkDescriptorSetAllocateInfo allocateInfo = {
-					VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
-					nullptr,
-					m_constantPool,
-					1,
-					&program->m_constantLayout
-				};
-				CR_RETURN_HR( Vk2Al( vkAllocateDescriptorSets( m_owner->m_device, &allocateInfo, &m_constantSet ) ) );
-				m_constantsDirty = true;
-			}
-
-			if( m_constantsDirty )
-			{
-				std::vector<VkWriteDescriptorSet> writes;
-				std::vector<VkDescriptorBufferInfo> bufferInfos;
-				writes.reserve( m_constantBuffers.size() );
-				bufferInfos.reserve( m_constantBuffers.size() );
-				for( auto it = begin( m_constantBuffers ); it != end( m_constantBuffers ); ++it )
-				{
-					VkDescriptorBufferInfo bufferInfo = { it->second, 0, VK_WHOLE_SIZE };
-					bufferInfos.push_back( bufferInfo );
-					VkWriteDescriptorSet write = {
-						VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
-						nullptr,
-						m_constantSet,
-						it->first,
-						0,
-						1,
-						VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-						nullptr,
-						&bufferInfos.back(),
-						nullptr
-					};
-					writes.push_back( write );
-				}
-				vkUpdateDescriptorSets( m_owner->m_device, uint32_t( writes.size() ), writes.data(), 0, nullptr );
-
-				m_constantsDirty = false;
-			}
-
-			vkCmdBindDescriptorSets(
-				m_commandBuffer,
-				VK_PIPELINE_BIND_POINT_GRAPHICS,
-				program->m_pipelineLayout,
+	if( !m_constantSet )
+	{
+		if( !m_constantPool )
+		{
+			VkDescriptorPoolSize poolSize = { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 32 };
+			VkDescriptorPoolCreateInfo poolInfo = {
+				VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+				nullptr,
 				0,
 				1,
-				&m_constantSet,
+				1,
+				&poolSize
+			};
+			CR_RETURN_HR( Vk2Al( vkCreateDescriptorPool( m_owner->m_device, &poolInfo, nullptr, &m_constantPool ) ) );
+		}
+
+		VkDescriptorSetAllocateInfo allocateInfo = {
+			VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+			nullptr,
+			m_constantPool,
+			1,
+			&program->m_constantLayout
+		};
+		CR_RETURN_HR( Vk2Al( vkAllocateDescriptorSets( m_owner->m_device, &allocateInfo, &m_constantSet ) ) );
+		m_constantsDirty = true;
+	}
+
+	if( m_constantsDirty )
+	{
+		std::vector<VkWriteDescriptorSet> writes;
+		std::vector<VkDescriptorBufferInfo> bufferInfos;
+		writes.reserve( m_constantBuffers.size() );
+		bufferInfos.reserve( m_constantBuffers.size() );
+		for( auto it = begin( m_constantBuffers ); it != end( m_constantBuffers ); ++it )
+		{
+			VkDescriptorBufferInfo bufferInfo = { it->second, 0, VK_WHOLE_SIZE };
+			bufferInfos.push_back( bufferInfo );
+			VkWriteDescriptorSet write = {
+				VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+				nullptr,
+				m_constantSet,
+				it->first,
 				0,
-				nullptr );
+				1,
+				VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+				nullptr,
+				&bufferInfos.back(),
+				nullptr
+			};
+			writes.push_back( write );
+		}
+		vkUpdateDescriptorSets( m_owner->m_device, uint32_t( writes.size() ), writes.data(), 0, nullptr );
+
+		m_constantsDirty = false;
+	}
+
+	vkCmdBindDescriptorSets(
+		m_commandBuffer,
+		bindPoint,
+		program->m_pipelineLayout,
+		0,
+		1,
+		&m_constantSet,
+		0,
+		nullptr );
+	return S_OK;
+}
+
+ALResult Tr2RenderContextAL::RunComputeShader( unsigned groupDimX, unsigned groupDimY, unsigned groupDimZ ) throw( )
+{
+	auto* program = m_pipelineSource.m_shaderProgram.m_program.get();
+	if( !program || !program->m_pipelineLayout || program->m_shaderInfo.empty() )
+	{
+		return E_INVALIDCALL;
+	}
+
+	// The compute pipeline is determined by the shader module and pipeline layout,
+	// both owned by the program. Cache it keyed by the layout, invalidating on
+	// program change (the same handle-reuse concern as the constant descriptor set).
+	if( m_computePipelineLayout != program->m_pipelineLayout )
+	{
+		m_computePipelineLayout = program->m_pipelineLayout;
+		if( m_computePipeline )
+		{
+			m_owner->DestroyLaterVulkan( m_computePipeline, vkDestroyPipeline );
+			m_computePipeline = VK_NULL_HANDLE;
 		}
 	}
+
+	if( !m_computePipeline )
+	{
+		VkComputePipelineCreateInfo pipelineInfo = {
+			VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
+			nullptr,
+			0,
+			program->m_shaderInfo[0],
+			program->m_pipelineLayout,
+			VK_NULL_HANDLE,
+			0
+		};
+		CR_RETURN_HR( Vk2Al( vkCreateComputePipelines( m_owner->m_device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &m_computePipeline ) ) );
+	}
+
+	vkCmdBindPipeline( m_commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, m_computePipeline );
+
+	if( m_resourceSet.IsValid() && m_resourceSet.m_resourceSet->m_descriptorSet && program->m_resourceLayout )
+	{
+		vkCmdBindDescriptorSets(
+			m_commandBuffer,
+			VK_PIPELINE_BIND_POINT_COMPUTE,
+			program->m_pipelineLayout,
+			1,
+			1,
+			&m_resourceSet.m_resourceSet->m_descriptorSet, 0, nullptr );
+	}
+
+	FORWARD_HR( BindConstantBuffers( VK_PIPELINE_BIND_POINT_COMPUTE ) );
+
+	vkCmdDispatch( m_commandBuffer, groupDimX, groupDimY, groupDimZ );
+
 	return S_OK;
 }
 

--- a/trinityal/vulkan/Tr2RenderContextVulkan.h
+++ b/trinityal/vulkan/Tr2RenderContextVulkan.h
@@ -1,0 +1,401 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   February 2019
+//    Copyright: CCP 2019
+//
+
+#pragma once
+
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "../Tr2RenderContextEnum.h"
+#include "../Tr2DrawUPHelper.h"
+#include "../include/Tr2ConstantBufferAL.h"
+#include "../include/Tr2ResourceSetAL.h"
+#include "../include/Tr2TextureAL.h"
+#include "../include/Tr2VertexLayoutAL.h"
+#include "../include/Tr2ShaderProgramAL.h"
+#include "../include/Tr2RenderPassAL.h"
+#include "../include/Tr2UpscalingAL.h"
+
+
+class Tr2ConstantBufferAL;
+class Tr2VertexLayoutAL;
+struct ITr2RenderContextEvents;
+
+class Tr2ShaderAL;
+class Tr2SamplerStateAL;
+class Tr2BufferAL;
+struct Tr2Viewport;
+class Tr2RtShaderTableAL;
+
+
+// -------------------------------------------------------------
+// Description:
+//   See http://carbon/wiki/Tr2RenderContext
+// -------------------------------------------------------------
+class Tr2RenderContextAL
+{
+public:
+	Tr2RenderContextAL() throw( );
+	~Tr2RenderContextAL() throw( );
+
+	void Destroy() throw( );
+	bool IsValid() const throw( );
+
+	static void SetPrimaryRenderContext( Tr2PrimaryRenderContextAL* )
+	{
+
+	}
+	static Tr2PrimaryRenderContextAL& GetPrimaryRenderContext()
+	{
+		return *static_cast<Tr2PrimaryRenderContextAL*>( nullptr );
+	}
+	static Tr2PrimaryRenderContextAL* GetPrimaryRenderContextPointer()
+	{
+		return nullptr;
+	}
+
+	ALResult BeginScene() throw( );
+	ALResult EndScene();
+
+
+	void ReleaseDeviceResources() throw( )
+	{
+
+	}
+
+
+	ALResult SetStreamSource( uint32_t stream, const Tr2BufferAL & buffer, uint32_t offset, uint32_t stride ) throw( );
+	ALResult SetIndices( const Tr2BufferAL & buffer ) throw( );
+
+	ALResult ClearUav( Tr2BufferAL& buffer, const float values[4] ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+	ALResult ClearUav( Tr2BufferAL& buffer, const uint32_t values[4] ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+
+	ALResult CopySubBuffer(
+		Tr2BufferAL& dest,
+		uint32_t destOffset,
+		Tr2BufferAL& src,
+		uint32_t offset,
+		uint32_t length )
+	{
+		return E_NOTIMPL;
+	}
+
+	ALResult SetTopology( Tr2RenderContextEnum::Topology topology ) throw( );
+	ALResult SetVertexLayout( const Tr2VertexLayoutAL& layout ) throw( );
+	ALResult SetShaderProgram( const Tr2ShaderProgramAL& shader ) throw( );
+
+	ALResult ClearUav( Tr2TextureAL& rt, uint32_t mip, const float values[4] ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+	ALResult ClearUav( Tr2TextureAL& rt, uint32_t mip, const uint32_t values[4] ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+
+	ALResult SetResourceSet( const Tr2ResourceSetAL& resourceSet ) throw( );
+	
+	ALResult DrawIndexedPrimitive(
+		uint32_t numVertices,
+		uint32_t startIndex,
+		uint32_t primitiveCount,
+		uint32_t minimumIndex = 0 ) throw( );
+	ALResult DrawPrimitive( uint32_t startVertex, uint32_t primitiveCount ) throw( );
+
+	ALResult DrawIndexedInstanced(
+		uint32_t numVertices,
+		uint32_t startIndex,
+		uint32_t primitiveCount,
+		uint32_t numInstances ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+	
+	ALResult DrawIndexedInstancedIndirect( Tr2BufferAL& params, uint32_t offset ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+	ALResult DrawInstancedIndirect( Tr2BufferAL& params, uint32_t offset ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+
+	ALResult DrawIndexedPrimitiveUP(
+		uint32_t numVertices,
+		uint32_t primitiveCount,
+		const uint32_t* indexData,
+		const void* vertexStreamZeroData,
+		uint32_t vertexStreamZeroStride ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+
+	ALResult DrawIndexedPrimitiveUP(
+		uint32_t numVertices,
+		uint32_t primitiveCount,
+		const uint16_t* indexData,
+		const void* vertexStreamZeroData,
+		uint32_t vertexStreamZeroStride ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+
+	ALResult DrawPrimitiveUP(
+		uint32_t primitiveCount,
+		const void* vertexStreamZeroData,
+		uint32_t VertexStreamZeroStride ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+
+	ALResult RunComputeShader( unsigned groupDimX, unsigned groupDimY, unsigned groupDimZ ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+	ALResult RunComputeShaderIndirect( Tr2BufferAL& indirectParams, unsigned offset ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+
+	ALResult DispatchRays( Tr2RtPipelineStateAL&, Tr2RtShaderTableAL&, const wchar_t*, uint32_t, uint32_t, uint32_t )
+	{
+		return E_FAIL;
+	}
+
+	ALResult SetRenderState( Tr2RenderContextEnum::RenderState state, uint32_t value ) throw( );
+	ALResult SetRenderStates( const uint32_t* stateValuePairs, uint32_t count ) throw( );
+
+	ALResult SetConstants(
+		const Tr2ConstantBufferAL& buffer,
+		Tr2RenderContextEnum::ShaderType constantType,
+		uint32_t registerIndex,
+		uint32_t unusedArgument = 0 ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+
+	ALResult SetDepthStencil( const Tr2TextureAL& depthStencil ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+	void SetReadOnlyDepth( bool enable ) throw( )
+	{
+
+	}
+	bool GetReadOnlyDepth() const
+	{
+		return false;
+	}
+	ALResult SetRenderTarget( const Tr2TextureAL& renderTarget, uint32_t slot = 0, uint32_t slice = 0 ) throw();
+
+	void RenderPassHint( const Tr2ColorAttachment& rt0, const Tr2DepthAttachment& depth );
+	void RenderPassHint( const Tr2ColorAttachment& rt0, const Tr2ColorAttachment& rt1, const Tr2DepthAttachment& depth );
+
+	static void DestroyMainThreadRenderContext()
+	{
+
+	}
+
+	// Helper function to clear the current primary backbuffer, depth and/or stencil.
+	ALResult Clear(
+		uint32_t clearFlags,
+		uint32_t color,
+		float depth,
+		uint32_t stencil = 0,
+		uint32_t slot = 0 ) throw( );
+
+	ALResult SetViewport( const Tr2Viewport& viewport ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+	ALResult GetViewport( Tr2Viewport& viewport ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+
+	ALResult PushRenderTarget( uint32_t slot = 0 ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+	ALResult PopRenderTarget( uint32_t slot = 0 ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+	ALResult PushDepthStencil() throw( )
+	{
+		return E_NOTIMPL;
+	}
+	ALResult PopDepthStencil() throw( )
+	{
+		return E_NOTIMPL;
+	}
+	ALResult GetRenderTargetSize( uint32_t& width, uint32_t& height, uint32_t slot = 0 ) throw( )
+	{
+		return E_NOTIMPL;
+	}
+
+	Tr2RenderContextEnum::PixelFormat GetBackBufferFormat() const throw( )
+	{
+		return Tr2RenderContextEnum::PIXEL_FORMAT_UNKNOWN;
+	}
+	
+	static const uint32_t SHADER_TYPE_MASK = 
+		( 1 << Tr2RenderContextEnum::VERTEX_SHADER ) |
+		( 1 << Tr2RenderContextEnum::PIXEL_SHADER ) |
+		( 1 << Tr2RenderContextEnum::COMPUTE_SHADER ) |
+		( 1 << Tr2RenderContextEnum::GEOMETRY_SHADER ) |
+		( 1 << Tr2RenderContextEnum::HULL_SHADER ) |
+		( 1 << Tr2RenderContextEnum::DOMAIN_SHADER );
+
+	// Debug helpers
+	size_t GetStackSizeRT( uint32_t RT = 0 )	const { return 0; }
+	size_t GetStackSizeDS()						const { return 0; }
+
+	void	ResetCapturePlayback()
+	{
+
+	}
+
+	// Set of variables that are the first thing we need in ApplyShadowState, keep them
+	// close for the cache -- don't put renderstates, renderStateEmulation or m_esm
+	// in between.
+
+	void AddGpuMarker( const char* marker )
+	{
+
+	}
+	void PushGpuMarker( const char* marker )
+	{
+
+	}
+
+	void PopGpuMarker()
+	{
+
+	}
+	ALResult GetGpuStateMarker( Tr2RenderContextEnum::RenderContextStatus& status, std::string& marker ) const
+	{
+		return E_NOTIMPL;
+	}
+	ALResult GetGpuPageFaultResource(
+		Tr2RenderContextEnum::PixelFormat& format,
+		uint64_t& size,
+		uint32_t& width,
+		uint32_t& height,
+		uint32_t& depth,
+		uint32_t& mips ) const
+	{
+		return E_NOTIMPL;
+	}
+
+	ALResult UseTextures( Tr2GpuUsage::Type usage, size_t count, Tr2TextureAL* textures );
+    ALResult UseAccelerationStructure( Tr2RtTopLevelAccelerationStructureAL tlas );
+
+    
+
+	Tr2UpscalingAL::Result EnableUpscaling( Tr2UpscalingAL::Technique tech, Tr2UpscalingAL::Setting setting, bool framegeneration, uint32_t adapter )
+	{
+		return Tr2UpscalingAL::Result::OK;
+	}
+
+	Tr2UpscalingContextAL* GetUpscalingContext( uint32_t upscalingContextID )
+	{
+		return nullptr;
+	}
+
+	Tr2UpscalingContextAL* CreateUpscalingContext( uint32_t displayWidth, uint32_t displayHeight, Tr2RenderContextEnum::PixelFormat sourceFormat, Tr2RenderContextEnum::DepthStencilFormat depthFormat )
+	{
+		return nullptr;
+	}
+
+	void DeleteUpscalingContext( uint32_t contextID )
+	{
+	}
+
+	std::vector<std::tuple<Tr2UpscalingAL::Technique, uint32_t, bool>> GetSupportedUpscalingTechniques( uint32_t adapter )
+	{
+		return std::vector<std::tuple<Tr2UpscalingAL::Technique, uint32_t, bool>>();
+	}
+
+	void Tr2PrimaryRenderContextAL::GetUpscalingSetup( Tr2UpscalingAL::Technique& technique, Tr2UpscalingAL::Setting& setting, bool& framegeneration )
+	{
+		technique = Tr2UpscalingAL::Technique::NONE;
+		setting = Tr2UpscalingAL::Setting::NATIVE;
+		framegeneration = false;
+	}
+
+	Tr2UpscalingAL::UpscalingInfo GetUpscalingInfo( uint32_t upscalingContextID );
+	{
+		return Tr2UpscalingAL::UpscalingInfo();
+	}
+
+	void MarkFrameEvent( Tr2RenderContextEnum::FrameEvent frameEvent )
+	{
+	}
+
+private:
+	ALResult SetPass();
+	ALResult CreateRenderPass( VkRenderPass& renderPass );
+	void UpdateFramebuffer();
+
+	ALResult SetPipeline();
+	ALResult CreatePipeline( VkPipeline& pipeline );
+
+	struct PipelineSource
+	{
+		Tr2VertexLayoutAL m_layout;
+		VkPrimitiveTopology m_topology;
+		Tr2ShaderProgramAL m_shaderProgram;
+		VkPipelineDepthStencilStateCreateInfo m_depthStencilState;
+		VkPipelineRasterizationStateCreateInfo m_rasterizationState;
+
+		VkPipelineColorBlendStateCreateInfo m_colorBlendState;
+		VkPipelineColorBlendAttachmentState m_attachmentBlend[4];
+
+		VkVertexInputBindingDescription m_streams[4];
+
+		size_t GetHash() const;
+	} m_pipelineSource;
+
+	struct RenderPassSource
+	{
+		VkAttachmentDescription m_rt[5]; //  0 - ds
+
+		size_t GetHash() const;
+	} m_renderPassSource;
+	bool m_dirtyPso;
+	bool m_dirtyPass;
+	std::pair<uint32_t, uint32_t> m_primitiveToVertexCount;
+
+	VkFramebuffer m_framebuffer;
+
+	Tr2ResourceSetAL m_resourceSet;
+public:
+	// If you need this, you're probably doing something wrong :P
+	//Tr2TextureAL&			GetDefaultBackBuffer()
+protected:
+	static const uint32_t RENDER_TARGET_COUNT = 4;
+	Tr2TextureAL m_boundRenderTargets[RENDER_TARGET_COUNT];
+	Tr2PrimaryRenderContextAL* m_owner;
+	VkRenderPass m_renderPass;
+
+public:
+	VkCommandBuffer m_commandBuffer;
+
+private:	
+
+	Tr2RenderContextAL( const Tr2RenderContextAL& ) /* = delete */;
+	Tr2RenderContextAL& operator=( const Tr2RenderContextAL& ) /* = delete */;
+
+};
+
+#endif

--- a/trinityal/vulkan/Tr2RenderContextVulkan.h
+++ b/trinityal/vulkan/Tr2RenderContextVulkan.h
@@ -29,6 +29,7 @@ class Tr2SamplerStateAL;
 class Tr2BufferAL;
 struct Tr2Viewport;
 class Tr2RtShaderTableAL;
+class Tr2RtTopLevelAccelerationStructureAL;
 
 
 // -------------------------------------------------------------
@@ -326,14 +327,14 @@ public:
 		return std::vector<std::tuple<Tr2UpscalingAL::Technique, uint32_t, bool>>();
 	}
 
-	void Tr2PrimaryRenderContextAL::GetUpscalingSetup( Tr2UpscalingAL::Technique& technique, Tr2UpscalingAL::Setting& setting, bool& framegeneration )
+	void GetUpscalingSetup( Tr2UpscalingAL::Technique& technique, Tr2UpscalingAL::Setting& setting, bool& framegeneration )
 	{
 		technique = Tr2UpscalingAL::Technique::NONE;
 		setting = Tr2UpscalingAL::Setting::NATIVE;
 		framegeneration = false;
 	}
 
-	Tr2UpscalingAL::UpscalingInfo GetUpscalingInfo( uint32_t upscalingContextID );
+	Tr2UpscalingAL::UpscalingInfo GetUpscalingInfo( uint32_t upscalingContextID )
 	{
 		return Tr2UpscalingAL::UpscalingInfo();
 	}

--- a/trinityal/vulkan/Tr2RenderContextVulkan.h
+++ b/trinityal/vulkan/Tr2RenderContextVulkan.h
@@ -17,7 +17,7 @@
 #include "../include/Tr2VertexLayoutAL.h"
 #include "../include/Tr2ShaderProgramAL.h"
 #include "../include/Tr2RenderPassAL.h"
-#include "../include/Tr2UpscalingAL.h"
+#include "../include/upscaling/Tr2UpscalingAL.h"
 
 
 class Tr2ConstantBufferAL;

--- a/trinityal/vulkan/Tr2RenderContextVulkan.h
+++ b/trinityal/vulkan/Tr2RenderContextVulkan.h
@@ -9,6 +9,8 @@
 
 #if TRINITY_PLATFORM == TRINITY_VULKAN
 
+#include <map>
+
 #include "../Tr2RenderContextEnum.h"
 #include "../Tr2DrawUPHelper.h"
 #include "../include/Tr2ConstantBufferAL.h"
@@ -179,10 +181,7 @@ public:
 		const Tr2ConstantBufferAL& buffer,
 		Tr2RenderContextEnum::ShaderType constantType,
 		uint32_t registerIndex,
-		uint32_t unusedArgument = 0 ) throw( )
-	{
-		return E_NOTIMPL;
-	}
+		uint32_t unusedArgument = 0 ) throw( );
 
 	ALResult SetDepthStencil( const Tr2TextureAL& depthStencil ) throw( )
 	{
@@ -380,6 +379,14 @@ private:
 	VkFramebuffer m_framebuffer;
 
 	Tr2ResourceSetAL m_resourceSet;
+
+	// Constant-buffer bindings (descriptor set 0), keyed by binding number. Set
+	// by SetConstants, written to a descriptor set and bound at SetPipeline time.
+	std::map<uint32_t, VkBuffer> m_constantBuffers;
+	bool m_constantsDirty;
+	VkDescriptorPool m_constantPool;
+	VkDescriptorSet m_constantSet;
+	VkDescriptorSetLayout m_boundConstantLayout;
 public:
 	// If you need this, you're probably doing something wrong :P
 	//Tr2TextureAL&			GetDefaultBackBuffer()

--- a/trinityal/vulkan/Tr2RenderContextVulkan.h
+++ b/trinityal/vulkan/Tr2RenderContextVulkan.h
@@ -160,10 +160,7 @@ public:
 		return E_NOTIMPL;
 	}
 
-	ALResult RunComputeShader( unsigned groupDimX, unsigned groupDimY, unsigned groupDimZ ) throw( )
-	{
-		return E_NOTIMPL;
-	}
+	ALResult RunComputeShader( unsigned groupDimX, unsigned groupDimY, unsigned groupDimZ ) throw( );
 	ALResult RunComputeShaderIndirect( Tr2BufferAL& indirectParams, unsigned offset ) throw( )
 	{
 		return E_NOTIMPL;
@@ -349,6 +346,7 @@ private:
 
 	ALResult SetPipeline();
 	ALResult CreatePipeline( VkPipeline& pipeline );
+	ALResult BindConstantBuffers( VkPipelineBindPoint bindPoint );
 
 	struct PipelineSource
 	{
@@ -387,6 +385,9 @@ private:
 	VkDescriptorPool m_constantPool;
 	VkDescriptorSet m_constantSet;
 	VkDescriptorSetLayout m_boundConstantLayout;
+
+	VkPipeline m_computePipeline;
+	VkPipelineLayout m_computePipelineLayout;
 public:
 	// If you need this, you're probably doing something wrong :P
 	//Tr2TextureAL&			GetDefaultBackBuffer()

--- a/trinityal/vulkan/Tr2ResourceSetALVulkan.cpp
+++ b/trinityal/vulkan/Tr2ResourceSetALVulkan.cpp
@@ -1,0 +1,154 @@
+#include "StdAfx.h"
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "Tr2ResourceSetALVulkan.h"
+#include "Tr2PrimaryRenderContextVulkan.h"
+#include "Tr2SamplerStateALVulkan.h"
+#include "Tr2TextureALVulkan.h"
+#include "Tr2ShaderProgramALVulkan.h"
+#include "UtilitiesVulkan.h"
+
+
+namespace TrinityALImpl
+{
+	Tr2ResourceSetAL::Tr2ResourceSetAL()
+		:m_owner( nullptr ),
+		m_pool( VK_NULL_HANDLE ),
+		m_descriptorSet( VK_NULL_HANDLE )
+	{
+	}
+
+	Tr2ResourceSetAL::~Tr2ResourceSetAL()
+	{
+		Destroy();
+	}
+
+	ALResult Tr2ResourceSetAL::Create( const Tr2ResourceSetDescriptionAL& description, const ::Tr2ShaderProgramAL& program, Tr2PrimaryRenderContextAL& renderContext )
+	{
+		Destroy();
+
+		if( !renderContext.IsValid() || !program.IsValid() )
+		{
+			return E_INVALIDARG;
+		}
+
+		if( program.GetRegisterMap() != description.m_registerMap )
+		{
+			return E_INVALIDARG;
+		}
+
+		if( program.m_program->m_resourceLayout )
+		{
+			VkDescriptorPoolCreateInfo poolDesc = { 
+				VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO, 
+				nullptr, 
+				0, 
+				1,
+				program.m_program->m_poolSizes.size(),
+				program.m_program->m_poolSizes.data()
+			};
+
+			CR_RETURN_HR( Vk2Al( vkCreateDescriptorPool( renderContext.m_device, &poolDesc, nullptr, &m_pool) ) );
+
+			VkDescriptorSetAllocateInfo allocateInfo = {
+				VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+				nullptr,
+				m_pool,
+				1,
+				&program.m_program->m_resourceLayout
+			};
+
+			CR_RETURN_HR( Vk2Al( vkAllocateDescriptorSets( renderContext.m_device, &allocateInfo, &m_descriptorSet ) ) );
+
+			std::vector<VkWriteDescriptorSet> descriptorWrites;
+			descriptorWrites.reserve( program.m_program->m_registerInput.size() );
+			std::vector<VkDescriptorImageInfo> imageInfos;
+			imageInfos.reserve( program.m_program->m_registerInput.size() );
+
+			for( auto it = begin( program.m_program->m_registerInput ); it != end( program.m_program->m_registerInput ); ++it )
+			{
+				VkWriteDescriptorSet d = {
+					VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+					nullptr,
+					m_descriptorSet,
+					it->binding,
+					0,
+					1,
+				};
+				switch( it->type )
+				{
+				case Tr2ShaderRegisterAL::CONSTANTS:
+					//d.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+					continue;
+				case Tr2ShaderRegisterAL::SAMPLER:
+				{
+					if( !description.m_samplers[description.m_registerMap.samplers[it->stage][it->registerIndex]].sampler.IsValid() )
+					{
+						return E_FAIL;
+					}
+					VkDescriptorImageInfo imageInfo = { description.m_samplers[description.m_registerMap.samplers[it->stage][it->registerIndex]].sampler.m_sampler->m_sampler };
+					imageInfos.push_back( imageInfo );
+					d.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
+					d.pImageInfo = &imageInfos.back();
+					break;
+				}
+				case Tr2ShaderRegisterAL::UAV:
+					return E_FAIL;
+				default:
+					d.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+					if( !description.m_srv[description.m_registerMap.srvs[it->stage][it->registerIndex]].texture.IsValid() )
+					{
+						return E_FAIL;
+					}
+					VkDescriptorImageInfo imageInfo = {  };
+					imageInfo.imageView = description.m_srv[description.m_registerMap.srvs[it->stage][it->registerIndex]].texture.m_texture->m_imageViews[0];
+					imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+					imageInfos.push_back( imageInfo );
+					d.pImageInfo = &imageInfos.back();
+					break;
+				}
+				descriptorWrites.push_back( d );
+			}
+			vkUpdateDescriptorSets( renderContext.m_device, uint32_t( descriptorWrites.size() ), descriptorWrites.data(), 0, nullptr );
+		}
+
+		m_owner = &renderContext;
+
+		return S_OK;
+	}
+
+	void Tr2ResourceSetAL::Destroy()
+	{
+		if( m_owner )
+		{
+			//m_owner->DestroyLaterVulkan( m_descriptorSets, vkFreeDescriptorSets );
+			m_owner->DestroyLaterVulkan( m_pool, vkDestroyDescriptorPool );
+			m_owner = nullptr;
+			m_pool = VK_NULL_HANDLE;
+			m_descriptorSet = VK_NULL_HANDLE;
+		}
+	}
+
+	bool Tr2ResourceSetAL::IsValid() const
+	{
+		return m_owner != nullptr;
+	}
+
+	Tr2ALMemoryType Tr2ResourceSetAL::GetMemoryClass() const
+	{
+		return AL_MEMORY_VIDEO;
+	}
+
+	void Tr2ResourceSetAL::Describe( Tr2DeviceResourceDescriptionAL& description ) const
+	{
+		description["type"] = "Tr2ResourceSetAL";
+	}
+
+	ALResult Tr2ResourceSetAL::SetName( const char* )
+	{
+		return E_NOTIMPL;
+	}
+}
+
+
+#endif

--- a/trinityal/vulkan/Tr2ResourceSetALVulkan.cpp
+++ b/trinityal/vulkan/Tr2ResourceSetALVulkan.cpp
@@ -5,6 +5,7 @@
 #include "Tr2PrimaryRenderContextVulkan.h"
 #include "Tr2SamplerStateALVulkan.h"
 #include "Tr2TextureALVulkan.h"
+#include "Tr2BufferALVulkan.h"
 #include "Tr2ShaderProgramALVulkan.h"
 #include "UtilitiesVulkan.h"
 
@@ -64,9 +65,22 @@ namespace TrinityALImpl
 			descriptorWrites.reserve( program.m_program->m_registerInput.size() );
 			std::vector<VkDescriptorImageInfo> imageInfos;
 			imageInfos.reserve( program.m_program->m_registerInput.size() );
+			std::vector<VkDescriptorBufferInfo> bufferInfos;
+			bufferInfos.reserve( program.m_program->m_registerInput.size() );
+			std::vector<VkBufferView> texelBufferViews;
+			texelBufferViews.reserve( program.m_program->m_registerInput.size() );
+
+			typedef Tr2ResourceSetDescriptionAL::Resource::Type ResourceType;
 
 			for( auto it = begin( program.m_program->m_registerInput ); it != end( program.m_program->m_registerInput ); ++it )
 			{
+				if( it->type == Tr2ShaderRegisterAL::CONSTANT_BUFFER )
+				{
+					// Constant buffers bind at descriptor set 0 (m_constantLayout),
+					// written by SetConstants; they are not part of this resource set.
+					continue;
+				}
+
 				VkWriteDescriptorSet d = {
 					VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
 					nullptr,
@@ -75,26 +89,8 @@ namespace TrinityALImpl
 					0,
 					1,
 				};
-				if( it->type & Tr2ShaderRegisterAL::UAV_REGISTER_FLAG )
-				{
-					// UAV is no longer a single value (Tr2ShaderAL.h:56-86); it is a
-					// family flagged by UAV_REGISTER_FLAG. This stays a coarse flag
-					// test rather than splitting by subtype: every UAV register has
-					// unconditionally returned E_FAIL here since 2019 (UAV
-					// descriptor-set *writes* were never implemented on Vulkan), so a
-					// flag test reproduces that behavior exactly for every subtype.
-					// Contrast with GetDescriptorType in Tr2ShaderProgramALVulkan.cpp,
-					// which must split because it feeds descriptor-set-layout/pool
-					// creation and is genuinely exercised by UAV_BUFFER today.
-					return E_FAIL;
-				}
 
-				switch( it->type )
-				{
-				case Tr2ShaderRegisterAL::CONSTANT_BUFFER:
-					//d.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-					continue;
-				case Tr2ShaderRegisterAL::SAMPLER:
+				if( it->type == Tr2ShaderRegisterAL::SAMPLER )
 				{
 					if( !description.m_samplers[description.m_registerMap.samplers[it->stage][it->registerIndex]].sampler.IsValid() )
 					{
@@ -104,21 +100,74 @@ namespace TrinityALImpl
 					imageInfos.push_back( imageInfo );
 					d.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
 					d.pImageInfo = &imageInfos.back();
-					break;
 				}
-				default:
-					d.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-					if( !description.m_srv[description.m_registerMap.srvs[it->stage][it->registerIndex]].texture.IsValid() )
+				else if( it->type & Tr2ShaderRegisterAL::UAV_REGISTER_FLAG )
+				{
+					const auto& resource = description.m_uav[description.m_registerMap.uavs[it->stage][it->registerIndex]];
+					if( resource.type == ResourceType::BUFFER )
 					{
-						return E_FAIL;
+						if( it->type == Tr2ShaderRegisterAL::UAV_BUFFER )
+						{
+							texelBufferViews.push_back( resource.buffer.m_buffer->GetBufferViewVulkan() );
+							d.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
+							d.pTexelBufferView = &texelBufferViews.back();
+						}
+						else
+						{
+							VkDescriptorBufferInfo bufferInfo = { resource.buffer.m_buffer->GetBufferVulkan(), 0, VK_WHOLE_SIZE };
+							bufferInfos.push_back( bufferInfo );
+							d.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+							d.pBufferInfo = &bufferInfos.back();
+						}
 					}
-					VkDescriptorImageInfo imageInfo = {  };
-					imageInfo.imageView = description.m_srv[description.m_registerMap.srvs[it->stage][it->registerIndex]].texture.m_texture->m_imageViews[0];
-					imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-					imageInfos.push_back( imageInfo );
-					d.pImageInfo = &imageInfos.back();
-					break;
+					else
+					{
+						if( !resource.texture.IsValid() )
+						{
+							return E_FAIL;
+						}
+						VkDescriptorImageInfo imageInfo = {  };
+						imageInfo.imageView = resource.texture.m_texture->m_imageViews[0];
+						imageInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+						imageInfos.push_back( imageInfo );
+						d.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+						d.pImageInfo = &imageInfos.back();
+					}
 				}
+				else
+				{
+					const auto& resource = description.m_srv[description.m_registerMap.srvs[it->stage][it->registerIndex]];
+					if( resource.type == ResourceType::BUFFER )
+					{
+						if( it->type == Tr2ShaderRegisterAL::SRV_BUFFER )
+						{
+							texelBufferViews.push_back( resource.buffer.m_buffer->GetBufferViewVulkan() );
+							d.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+							d.pTexelBufferView = &texelBufferViews.back();
+						}
+						else
+						{
+							VkDescriptorBufferInfo bufferInfo = { resource.buffer.m_buffer->GetBufferVulkan(), 0, VK_WHOLE_SIZE };
+							bufferInfos.push_back( bufferInfo );
+							d.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+							d.pBufferInfo = &bufferInfos.back();
+						}
+					}
+					else
+					{
+						if( !resource.texture.IsValid() )
+						{
+							return E_FAIL;
+						}
+						VkDescriptorImageInfo imageInfo = {  };
+						imageInfo.imageView = resource.texture.m_texture->m_imageViews[0];
+						imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+						imageInfos.push_back( imageInfo );
+						d.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+						d.pImageInfo = &imageInfos.back();
+					}
+				}
+
 				descriptorWrites.push_back( d );
 			}
 			vkUpdateDescriptorSets( renderContext.m_device, uint32_t( descriptorWrites.size() ), descriptorWrites.data(), 0, nullptr );

--- a/trinityal/vulkan/Tr2ResourceSetALVulkan.cpp
+++ b/trinityal/vulkan/Tr2ResourceSetALVulkan.cpp
@@ -75,9 +75,23 @@ namespace TrinityALImpl
 					0,
 					1,
 				};
+				if( it->type & Tr2ShaderRegisterAL::UAV_REGISTER_FLAG )
+				{
+					// UAV is no longer a single value (Tr2ShaderAL.h:56-86); it is a
+					// family flagged by UAV_REGISTER_FLAG. This stays a coarse flag
+					// test rather than splitting by subtype: every UAV register has
+					// unconditionally returned E_FAIL here since 2019 (UAV
+					// descriptor-set *writes* were never implemented on Vulkan), so a
+					// flag test reproduces that behavior exactly for every subtype.
+					// Contrast with GetDescriptorType in Tr2ShaderProgramALVulkan.cpp,
+					// which must split because it feeds descriptor-set-layout/pool
+					// creation and is genuinely exercised by UAV_BUFFER today.
+					return E_FAIL;
+				}
+
 				switch( it->type )
 				{
-				case Tr2ShaderRegisterAL::CONSTANTS:
+				case Tr2ShaderRegisterAL::CONSTANT_BUFFER:
 					//d.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
 					continue;
 				case Tr2ShaderRegisterAL::SAMPLER:
@@ -92,8 +106,6 @@ namespace TrinityALImpl
 					d.pImageInfo = &imageInfos.back();
 					break;
 				}
-				case Tr2ShaderRegisterAL::UAV:
-					return E_FAIL;
 				default:
 					d.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 					if( !description.m_srv[description.m_registerMap.srvs[it->stage][it->registerIndex]].texture.IsValid() )

--- a/trinityal/vulkan/Tr2ResourceSetALVulkan.h
+++ b/trinityal/vulkan/Tr2ResourceSetALVulkan.h
@@ -1,0 +1,39 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   February 2019
+//    Copyright: CCP 2019
+//
+
+#pragma once
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "../include/Tr2ResourceSetAL.h"
+
+namespace TrinityALImpl
+{
+	class Tr2ResourceSetAL: public Tr2DeviceResourceAL<Tr2ResourceSetAL>
+	{
+	public:
+		Tr2ResourceSetAL();
+		~Tr2ResourceSetAL();
+
+		ALResult Create( const Tr2ResourceSetDescriptionAL& description, const ::Tr2ShaderProgramAL& program, Tr2PrimaryRenderContextAL& renderContext );
+		void Destroy();
+
+		bool IsValid() const;
+		Tr2ALMemoryType GetMemoryClass() const;
+		void Describe( Tr2DeviceResourceDescriptionAL& description ) const;
+		ALResult SetName( const char* name );
+
+	private:
+		Tr2PrimaryRenderContextAL *m_owner;
+
+		VkDescriptorPool m_pool;
+		VkDescriptorSet m_descriptorSet;
+
+		friend class ::Tr2RenderContextAL;
+	};
+}
+
+#endif

--- a/trinityal/vulkan/Tr2SamplerStateALVulkan.cpp
+++ b/trinityal/vulkan/Tr2SamplerStateALVulkan.cpp
@@ -1,0 +1,104 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   May 2019
+//    Copyright: CCP 2019
+//
+
+#include "StdAfx.h"
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "Tr2SamplerStateALVulkan.h"
+#include "Tr2PrimaryRenderContextVulkan.h"
+#include "UtilitiesVulkan.h"
+
+
+namespace TrinityALImpl
+{
+	Tr2SamplerStateAL::Tr2SamplerStateAL()
+		:m_sampler( VK_NULL_HANDLE ),
+		m_owner( nullptr )
+	{
+	}
+
+	Tr2SamplerStateAL::~Tr2SamplerStateAL()
+	{
+		Destroy();
+	}
+
+	ALResult Tr2SamplerStateAL::Create( const Tr2SamplerDescription& description, Tr2PrimaryRenderContextAL &renderContext )
+	{
+		Destroy();
+		if( !renderContext.IsValid() )
+		{
+			return E_INVALIDARG;
+		}
+
+		VkBool32 isAnisotropic = VK_FALSE;
+		if( description.m_maxAnisotropy > 0 )
+		{
+			if( description.m_minFilter == Tr2RenderContextEnum::TF_ANISOTROPIC || description.m_mipFilter == Tr2RenderContextEnum::TF_ANISOTROPIC )
+			{
+				isAnisotropic = VK_TRUE;
+			}
+		}
+		VkSamplerCreateInfo createInfo = {
+			VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
+			nullptr,
+			0,
+			description.m_magFilter == Tr2RenderContextEnum::TF_POINT ? VK_FILTER_NEAREST : VK_FILTER_LINEAR,
+			description.m_minFilter == Tr2RenderContextEnum::TF_POINT ? VK_FILTER_NEAREST : VK_FILTER_LINEAR,
+			description.m_mipFilter <= Tr2RenderContextEnum::TF_POINT ? VK_SAMPLER_MIPMAP_MODE_NEAREST : VK_SAMPLER_MIPMAP_MODE_LINEAR,
+			VkSamplerAddressMode( description.m_addressU - 1 ),
+			VkSamplerAddressMode( description.m_addressV - 1 ),
+			VkSamplerAddressMode( description.m_addressW - 1 ),
+			description.m_mipLODBias,
+			isAnisotropic,
+			float( description.m_maxAnisotropy ),
+			description.m_isComparisonFilter,
+			VkCompareOp( description.m_comparisonFunc - 1),
+			description.m_minLOD,
+			description.m_maxLOD,
+			VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK,
+			VK_FALSE
+		};
+
+		CR_RETURN_HR( Vk2Al( vkCreateSampler( renderContext.m_device, &createInfo, nullptr, &m_sampler ) ) );
+		m_owner = &renderContext;
+
+		return S_OK;
+	}
+
+	void Tr2SamplerStateAL::Destroy()
+	{
+		if( m_owner )
+		{
+			m_owner->DestroyLaterVulkan( m_sampler, vkDestroySampler );
+			m_sampler = VK_NULL_HANDLE;
+			m_owner = nullptr;
+		}
+	}
+
+	bool Tr2SamplerStateAL::IsValid() const
+	{
+		return m_sampler != VK_NULL_HANDLE;
+	}
+
+	Tr2ALMemoryType Tr2SamplerStateAL::GetMemoryClass() const
+	{
+		return AL_MEMORY_VIDEO;
+	}
+
+	void Tr2SamplerStateAL::Describe( Tr2DeviceResourceDescriptionAL& description ) const
+	{
+		description["type"] = "Tr2SamplerStateAL";
+	}
+
+	ALResult Tr2SamplerStateAL::SetName( const char* )
+	{
+		return E_NOTIMPL;
+	}
+}
+
+
+#endif

--- a/trinityal/vulkan/Tr2SamplerStateALVulkan.cpp
+++ b/trinityal/vulkan/Tr2SamplerStateALVulkan.cpp
@@ -98,6 +98,11 @@ namespace TrinityALImpl
 	{
 		return E_NOTIMPL;
 	}
+
+	uint32_t Tr2SamplerStateAL::GetIndexInHeap() const
+	{
+		return 0xffffffff;
+	}
 }
 
 

--- a/trinityal/vulkan/Tr2SamplerStateALVulkan.h
+++ b/trinityal/vulkan/Tr2SamplerStateALVulkan.h
@@ -1,0 +1,38 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   February 2019
+//    Copyright: CCP 2019
+//
+
+#pragma once
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "../include/Tr2SamplerStateAL.h"
+
+namespace TrinityALImpl
+{
+	class Tr2SamplerStateAL : public Tr2DeviceResourceAL<Tr2SamplerStateAL>
+	{
+	public:
+		Tr2SamplerStateAL();
+		~Tr2SamplerStateAL();
+
+		ALResult Create( const Tr2SamplerDescription& description, Tr2PrimaryRenderContextAL &renderContext );
+		void Destroy();
+
+		bool IsValid() const;
+		Tr2ALMemoryType GetMemoryClass() const;
+		void Describe( Tr2DeviceResourceDescriptionAL& description ) const;
+		ALResult SetName( const char* name );
+
+	private:
+		VkSampler m_sampler;
+		Tr2PrimaryRenderContextAL* m_owner;
+
+		friend class TrinityALImpl::Tr2ResourceSetAL;
+	};
+
+}
+
+#endif

--- a/trinityal/vulkan/Tr2SamplerStateALVulkan.h
+++ b/trinityal/vulkan/Tr2SamplerStateALVulkan.h
@@ -25,6 +25,7 @@ namespace TrinityALImpl
 		Tr2ALMemoryType GetMemoryClass() const;
 		void Describe( Tr2DeviceResourceDescriptionAL& description ) const;
 		ALResult SetName( const char* name );
+		uint32_t GetIndexInHeap() const;
 
 	private:
 		VkSampler m_sampler;

--- a/trinityal/vulkan/Tr2ShaderALVulkan.cpp
+++ b/trinityal/vulkan/Tr2ShaderALVulkan.cpp
@@ -1,0 +1,142 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   April 2019
+//    Copyright: CCP 2019
+//
+
+#include "StdAfx.h"
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "Tr2ShaderALVulkan.h"
+#include "Tr2PrimaryRenderContextVulkan.h"
+#include "UtilitiesVulkan.h"
+
+
+namespace TrinityALImpl
+{
+
+	Tr2ShaderAL::Tr2ShaderAL()
+		:m_shader( 0 ),
+		m_owner( nullptr )
+	{
+	}
+
+	Tr2ShaderAL::~Tr2ShaderAL()
+	{
+		Destroy();
+	}
+
+	ALResult Tr2ShaderAL::Create(
+		Tr2RenderContextEnum::ShaderType type,
+		const Tr2ShaderBytecodeAL& bytecode,
+		const Tr2ShaderSignatureAL& signature,
+		const char* shaderPath,
+		Tr2PrimaryRenderContextAL &renderContext )
+	{
+		Destroy();
+
+		if( !bytecode.size )
+		{
+			return E_INVALIDARG;
+		}
+		if( !renderContext.IsValid() )
+		{
+			return E_INVALIDARG;
+		}
+
+		VkShaderModuleCreateInfo shader_module_create_info = {
+			VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
+			nullptr,
+			0,
+			bytecode.size,
+			reinterpret_cast<const uint32_t*>( bytecode.bytecode )
+		};
+
+		VkShaderModule shader;
+		CR_RETURN_HR( Vk2Al( vkCreateShaderModule( renderContext.m_device, &shader_module_create_info, nullptr, &shader ) ) );
+
+		m_bytecode.resize( "Tr2ShaderAL::m_bytecode", bytecode.size );
+		if( m_bytecode.empty() )
+		{
+			vkDestroyShaderModule( renderContext.m_device, shader, nullptr );
+			return E_OUTOFMEMORY;
+		}
+		m_shader = shader;
+		m_owner = &renderContext;
+		m_signature = signature;
+		m_type = type;
+		memcpy( m_bytecode.get(), bytecode.bytecode, bytecode.size );
+
+		return S_OK;
+	}
+
+	void Tr2ShaderAL::Destroy()
+	{
+		if( m_shader )
+		{
+			vkDestroyShaderModule( m_owner->m_device, m_shader, nullptr );
+			m_shader = 0;
+			m_owner = nullptr;
+			m_bytecode.clear();
+			m_type = Tr2RenderContextEnum::INVALID_SHADER;
+			m_signature = Tr2ShaderSignatureAL();
+			m_type = Tr2RenderContextEnum::INVALID_SHADER;
+		}
+	}
+
+	bool Tr2ShaderAL::IsValid() const
+	{
+		return m_shader != 0;
+	}
+
+	bool Tr2ShaderAL::operator==( const Tr2ShaderAL& shader ) const
+	{
+		return this == &shader;
+	}
+
+	Tr2RenderContextEnum::ShaderType Tr2ShaderAL::GetType() const 
+	{ 
+		return m_type;
+	}
+	
+	ALResult Tr2ShaderAL::GetBytecode( Tr2ShaderBytecodeAL& bytecode ) const
+	{
+		if( !IsValid() )
+		{
+			bytecode = Tr2ShaderBytecodeAL();
+			return E_INVALIDCALL;
+		}
+		bytecode.bytecode = m_bytecode.get();
+		bytecode.size = m_bytecode.size();
+		return S_OK;
+	}
+
+	const Tr2ShaderSignatureAL& Tr2ShaderAL::GetSignature() const
+	{
+		return m_signature;
+	}
+
+	Tr2ALMemoryType Tr2ShaderAL::GetMemoryClass() const 
+	{ 
+		return AL_MEMORY_MANAGED; 
+	}
+
+	void Tr2ShaderAL::SetNullShaderType( Tr2RenderContextEnum::ShaderType type )
+	{
+		Destroy();
+		m_type = type;
+	}
+
+	void Tr2ShaderAL::Describe( Tr2DeviceResourceDescriptionAL& description ) const
+	{
+		description["type"] = "Tr2ShaderAL";
+	}
+
+	ALResult Tr2ShaderAL::SetName( const char* )
+	{
+		return E_NOTIMPL;
+	}
+
+}
+#endif

--- a/trinityal/vulkan/Tr2ShaderALVulkan.h
+++ b/trinityal/vulkan/Tr2ShaderALVulkan.h
@@ -1,0 +1,69 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   February 2019
+//    Copyright: CCP 2019
+//
+
+#pragma once
+
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "../include/Tr2ShaderAL.h"
+
+
+namespace TrinityALImpl
+{
+	class Tr2ShaderProgramAL;
+
+	// -------------------------------------------------------------
+// Description:
+//   A low level wrapper around shaders / shader programs. DX11
+//   specific version will also hold on to byte code for the 
+//   shader as this is needed for construction of input layouts.
+//   Avoid using this class directly; instead use effects and Tr2Effect.
+//   32bit - no support for shader blobs > 4 gig
+// -------------------------------------------------------------
+	class Tr2ShaderAL :
+		public Tr2DeviceResourceAL<Tr2ShaderAL>
+	{
+	public:
+		Tr2ShaderAL();
+		~Tr2ShaderAL();
+
+		ALResult Create(
+			Tr2RenderContextEnum::ShaderType type,
+			const Tr2ShaderBytecodeAL& bytecode,
+			const Tr2ShaderSignatureAL& signature,
+			const char* shaderPath,
+			Tr2PrimaryRenderContextAL &renderContext );
+		void Destroy();
+		bool IsValid() const;
+
+		bool operator==( const Tr2ShaderAL& shader ) const;
+
+		Tr2RenderContextEnum::ShaderType GetType() const;
+		ALResult GetBytecode( Tr2ShaderBytecodeAL& bytecode ) const;
+		const Tr2ShaderSignatureAL& GetSignature() const;
+
+		Tr2ALMemoryType GetMemoryClass() const;
+
+		void SetNullShaderType( Tr2RenderContextEnum::ShaderType type );
+		void Describe( Tr2DeviceResourceDescriptionAL& description ) const;
+		ALResult SetName( const char* name );
+
+	private:
+		Tr2ShaderAL( const Tr2ShaderAL& shader );
+		Tr2ShaderAL& operator=( const Tr2ShaderAL& shader );
+
+		VkShaderModule m_shader;
+		Tr2PrimaryRenderContextAL* m_owner;
+		Tr2ShaderSignatureAL m_signature;
+		CcpMallocBuffer m_bytecode;
+		Tr2RenderContextEnum::ShaderType m_type;
+
+		friend class TrinityALImpl::Tr2ShaderProgramAL;
+	};
+}
+
+#endif 

--- a/trinityal/vulkan/Tr2ShaderBindingABIVulkan.h
+++ b/trinityal/vulkan/Tr2ShaderBindingABIVulkan.h
@@ -1,0 +1,103 @@
+////////////////////////////////////////////////////////////
+//
+//    Copyright: CCP 2026
+//
+
+#pragma once
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "../include/Tr2ShaderAL.h"
+#include "../Tr2RenderContextEnum.h"
+
+// The Vulkan binding ABI, in one place.
+//
+// Three artifacts have to agree on these numbers, in three languages:
+//
+//   1. Tr2ShaderProgramALVulkan.cpp -- builds VkDescriptorSetLayoutBindings from them.
+//   2. trinityal/tests/CMakeLists.txt -- computes dxc's -fvk-{b,t,s,u}-shift arguments
+//      from the same arithmetic, so the emitted SPIR-V decorations land on the same
+//      numbers.
+//   3. trinityal/tests/Shaders.vulkan/*.{vsh,psh,csh} -- declare the register spaces
+//      (b in space0, t/s/u in space1) that select the descriptor set.
+//
+// Nothing used to tie them together, and all three of this branch's ABI defects were
+// the same failure with no assertion behind it: Phase 1's Tasks 4e and 4f moved every
+// SRV/UAV binding as a side effect of a descriptor-*type* fix, and
+// SampleTextureMipFromTexCoord.psh's DX9-style `register( ps, c0 )` silently escaped
+// -fvk-b-shift entirely. trinityal/tests/ShaderBindingABI.cpp now asserts the contract
+// by walking the shipped SPIR-V modules -- and it derives its expectations by calling
+// straight into this header, so there is one source of truth for the arithmetic rather
+// than a table of expected numbers that can drift away from the code.
+//
+// This header deliberately mentions no Vulkan type, so the test can include it without
+// pulling in vulkan/vulkan.h.
+namespace Tr2VulkanBindingABI
+{
+	// One 32-slot window per shader stage, four consecutive stage windows... six,
+	// actually: the class block is 6 * REGISTER_SIZE so that all six
+	// Tr2RenderContextEnum::ShaderType values get a window inside one class block.
+	// These are 2019's values, restored by Phase 2a Task 1.
+	static const uint32_t REGISTER_SIZE = 32;
+	static const uint32_t CLASS_BLOCK = 6 * REGISTER_SIZE;
+
+	// The binding-number block a register lives in: the four HLSL register classes
+	// b/s/t/u. This is deliberately NOT the six-way descriptor-*kind* mapping
+	// (RegisterTypeIndex in Tr2ShaderProgramALVulkan.cpp) -- that one answers "which
+	// VkDescriptorType", which Vulkan splits six ways; this one answers "which binding
+	// block", which HLSL splits four ways. Conflating the two is what Tasks 4e and 4f
+	// did.
+	//
+	// b and u sharing block 0 is safe: CONSTANT_BUFFER registers go into
+	// m_constantLayout (descriptor set 0) and every other register into
+	// m_resourceLayout (set 1), so the two never share a set.
+	enum RegisterClass
+	{
+		REGISTER_CLASS_CONSTANT_BUFFER = 0,   // b
+		REGISTER_CLASS_SRV             = 1,   // t
+		REGISTER_CLASS_SAMPLER         = 2,   // s
+		REGISTER_CLASS_UAV             = 0    // u
+	};
+
+	// Descriptor sets. Constants live alone in set 0 so that the b/u block collision
+	// above cannot bite; everything else shares set 1. The shader side spells this as
+	// the register space (`space1` on every t/s/u declaration).
+	enum DescriptorSet
+	{
+		DESCRIPTOR_SET_CONSTANTS = 0,
+		DESCRIPTOR_SET_RESOURCES = 1
+	};
+
+	inline uint32_t RegisterClassOffset( Tr2ShaderRegisterAL::RegisterType registerType )
+	{
+		if( registerType & Tr2ShaderRegisterAL::UAV_REGISTER_FLAG )
+		{
+			return REGISTER_CLASS_UAV;
+		}
+		if( registerType & Tr2ShaderRegisterAL::SRV_REGISTER_FLAG )
+		{
+			return REGISTER_CLASS_SRV;
+		}
+		return registerType == Tr2ShaderRegisterAL::SAMPLER
+			? REGISTER_CLASS_SAMPLER : REGISTER_CLASS_CONSTANT_BUFFER;
+	}
+
+	inline uint32_t DescriptorSetIndex( Tr2ShaderRegisterAL::RegisterType registerType )
+	{
+		return registerType == Tr2ShaderRegisterAL::CONSTANT_BUFFER
+			? DESCRIPTOR_SET_CONSTANTS : DESCRIPTOR_SET_RESOURCES;
+	}
+
+	// binding = registerIndex + classOffset * 6 * 32 + shaderType * 32
+	inline uint32_t BindingNumber(
+		Tr2ShaderRegisterAL::RegisterType registerType,
+		uint32_t registerIndex,
+		Tr2RenderContextEnum::ShaderType shaderType )
+	{
+		return registerIndex
+			+ RegisterClassOffset( registerType ) * CLASS_BLOCK
+			+ uint32_t( shaderType ) * REGISTER_SIZE;
+	}
+}
+
+#endif

--- a/trinityal/vulkan/Tr2ShaderProgramALVulkan.cpp
+++ b/trinityal/vulkan/Tr2ShaderProgramALVulkan.cpp
@@ -1,0 +1,283 @@
+#include "StdAfx.h"
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "Tr2ShaderProgramALVulkan.h"
+#include "Tr2PrimaryRenderContextVulkan.h"
+#include "Tr2ShaderALVulkan.h"
+#include "UtilitiesVulkan.h"
+
+
+using namespace Tr2RenderContextEnum;
+
+
+namespace
+{
+	VkDescriptorType GetDescriptorType( Tr2ShaderRegisterAL::RegisterType registerType )
+	{
+		switch( registerType )
+		{
+		case Tr2ShaderRegisterAL::CONSTANTS:
+			return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+		case Tr2ShaderRegisterAL::SAMPLER:
+			return VK_DESCRIPTOR_TYPE_SAMPLER;
+		case Tr2ShaderRegisterAL::UAV:
+			return VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+		default:
+			return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+		}
+	}
+}
+
+namespace TrinityALImpl
+{
+	Tr2ShaderProgramAL::Tr2ShaderProgramAL()
+		:m_owner( nullptr ),
+		m_resourceLayout( VK_NULL_HANDLE ),
+		m_constantLayout( VK_NULL_HANDLE ),
+		m_pipelineLayout( VK_NULL_HANDLE )
+	{
+	}
+
+	Tr2ShaderProgramAL::~Tr2ShaderProgramAL()
+	{
+		Destroy();
+	}
+
+	ALResult Tr2ShaderProgramAL::Create( ::Tr2ShaderAL* shaders, size_t count, Tr2PrimaryRenderContextAL& renderContext )
+	{
+		Destroy();
+
+		if( !renderContext.IsValid() )
+		{
+			return E_INVALIDCALL;
+		}
+
+		if( count == 0 )
+		{
+			return E_INVALIDARG;
+		}
+
+		uint32_t bitmask = 0;
+
+		for( size_t i = 0; i < count; ++i )
+		{
+			if( !shaders[i].IsValid() )
+			{
+				return E_INVALIDARG;
+			}
+			auto mask = 1 << shaders[i].GetType();
+			if( ( mask & bitmask ) != 0 )
+			{
+				return E_INVALIDARG;
+			}
+			bitmask |= mask;
+		}
+		auto csBit = 1 << COMPUTE_SHADER;
+		if( ( bitmask & csBit ) != 0 && ( bitmask & ~csBit ) != 0 )
+		{
+			return E_INVALIDARG;
+		}
+
+		m_shaderInfo.reserve( count );
+		m_shaders.reserve( count );
+
+		uint32_t poolSizes[4] = { 0 };
+
+		uint32_t registerOffsets[] = { 0, 2, 1, 0 };
+
+		std::vector<VkDescriptorSetLayoutBinding> resourceSetBindings, constantBindings;
+
+		for( size_t i = 0; i < count; ++i )
+		{
+			VkPipelineShaderStageCreateInfo info = {
+				VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+				nullptr,
+			};
+			switch( shaders[i].GetType() )
+			{
+			case VERTEX_SHADER:
+				info.stage = VK_SHADER_STAGE_VERTEX_BIT;
+				m_shaderInputs = shaders[i].m_shader->m_signature.pipelineInputs;
+				break;
+			case PIXEL_SHADER:
+				info.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+				break;
+			case COMPUTE_SHADER:
+				info.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+				break;
+			case GEOMETRY_SHADER:
+				info.stage = VK_SHADER_STAGE_GEOMETRY_BIT;
+				break;
+			case HULL_SHADER:
+				info.stage = VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
+				break;
+			case DOMAIN_SHADER:
+				info.stage = VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
+				break;
+			}
+			info.module = shaders[i].m_shader->m_shader;
+			info.pName = "main";
+			m_shaderInfo.push_back( info );
+			m_shaders.push_back( shaders[i] );
+
+			uint32_t registerSize = 32;
+
+			auto& inputs = shaders[i].m_shader->m_signature.registers;
+			for( auto it = begin( inputs ); it != end( inputs ); ++it )
+			{
+				VkDescriptorSetLayoutBinding binding = {
+					it->registerIndex + registerOffsets[it->registerType] * 6 * registerSize + shaders[i].GetType() * registerSize,
+					GetDescriptorType( it->registerType ),
+					1,
+					info.stage,
+					nullptr
+				};
+
+				if( it->registerType == Tr2ShaderRegisterAL::CONSTANTS )
+				{
+					constantBindings.push_back( binding );
+				}
+				else
+				{
+					++poolSizes[it->registerType];
+					resourceSetBindings.push_back( binding );
+				}
+
+				RegisterInput ri = { binding.binding, shaders[i].GetType(), it->registerIndex, it->registerType };
+				m_registerInput.push_back( ri );
+			}
+		}
+
+		if( !resourceSetBindings.empty() )
+		{
+			VkDescriptorSetLayoutCreateInfo layoutInfo = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, nullptr, 0 };
+			layoutInfo.bindingCount = uint32_t( resourceSetBindings.size() );
+			layoutInfo.pBindings = resourceSetBindings.data();
+
+			VkDescriptorSetLayout layout;
+			CR_RETURN_HR( Vk2Al( vkCreateDescriptorSetLayout( renderContext.m_device, &layoutInfo, nullptr, &layout ) ) );
+
+			m_resourceLayout = layout;
+
+			for( uint32_t i = 0; i < _countof( poolSizes ); ++i )
+			{
+				if( !poolSizes[i] )
+				{
+					continue;
+				}
+				VkDescriptorPoolSize poolSize = { GetDescriptorType( Tr2ShaderRegisterAL::RegisterType( i ) ), poolSizes[i] };
+				m_poolSizes.push_back( poolSize );
+			}
+		}
+
+		if( !constantBindings.empty() )
+		{
+			VkDescriptorSetLayoutCreateInfo layoutInfo = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, nullptr, 0 };
+			layoutInfo.bindingCount = uint32_t( constantBindings.size() );
+			layoutInfo.pBindings = constantBindings.data();
+
+			VkDescriptorSetLayout layout;
+			CR_RETURN_HR( Vk2Al( vkCreateDescriptorSetLayout( renderContext.m_device, &layoutInfo, nullptr, &layout ) ) );
+
+			m_constantLayout = layout;
+
+			for( uint32_t i = 0; i < _countof( poolSizes ); ++i )
+			{
+				if( !poolSizes[i] )
+				{
+					continue;
+				}
+				VkDescriptorPoolSize poolSize = { GetDescriptorType( Tr2ShaderRegisterAL::RegisterType( i ) ), poolSizes[i] };
+				m_poolSizes.push_back( poolSize );
+			}
+		}
+
+		uint32_t size = 0;
+		VkDescriptorSetLayout layouts[2];
+		if( m_resourceLayout || m_constantLayout )
+		{
+			if( m_constantLayout )
+			{
+				layouts[size++] = m_constantLayout;
+			}
+			else
+			{
+				VkDescriptorSetLayoutCreateInfo emptyLayoutInfo = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, nullptr, 0, 0, nullptr };
+				VkDescriptorSetLayout emptyLayout = VK_NULL_HANDLE;
+				CR_RETURN_HR( Vk2Al( vkCreateDescriptorSetLayout( renderContext.m_device, &emptyLayoutInfo, nullptr, &emptyLayout ) ) );
+
+				layouts[size++] = emptyLayout;
+			}
+			if( m_resourceLayout )
+			{
+				layouts[size++] = m_resourceLayout;
+			}
+		}
+		VkPipelineLayoutCreateInfo layoutInfo = {
+			VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+			nullptr,
+			0,
+			size,
+			layouts,
+			0,
+			nullptr
+		};
+
+		CR_RETURN_HR( Vk2Al( vkCreatePipelineLayout( renderContext.m_device, &layoutInfo, nullptr, &m_pipelineLayout ) ) );
+		m_owner = &renderContext;
+
+		m_registerMap = Tr2RegisterMapAL( shaders, count );
+
+		return S_OK;
+	}
+
+
+	void Tr2ShaderProgramAL::Destroy()
+	{
+		if( m_owner )
+		{
+			m_owner->DestroyLaterVulkan( m_resourceLayout, vkDestroyDescriptorSetLayout );
+			m_owner->DestroyLaterVulkan( m_constantLayout, vkDestroyDescriptorSetLayout );
+			m_owner->DestroyLaterVulkan( m_pipelineLayout, vkDestroyPipelineLayout );
+			m_resourceLayout = VK_NULL_HANDLE;
+			m_constantLayout = VK_NULL_HANDLE;
+			m_pipelineLayout = VK_NULL_HANDLE;
+			m_owner = nullptr;
+		}
+		m_shaders.clear();
+		m_shaderInfo.clear();
+		m_shaderInputs.clear();
+
+		m_poolSizes.clear();
+		m_registerInput.clear();
+		m_registerMap = Tr2RegisterMapAL();
+	}
+
+	bool Tr2ShaderProgramAL::IsValid() const
+	{
+		return !m_shaderInfo.empty();
+	}
+
+	Tr2ALMemoryType Tr2ShaderProgramAL::GetMemoryClass() const
+	{
+		return AL_MEMORY_MANAGED;
+	}
+
+	void Tr2ShaderProgramAL::Describe( Tr2DeviceResourceDescriptionAL& description ) const
+	{
+		description["type"] = "Tr2ShaderProgramAL";
+	}
+
+	const Tr2RegisterMapAL& Tr2ShaderProgramAL::GetRegisterMap() const
+	{
+		return m_registerMap;
+	}
+
+	ALResult Tr2ShaderProgramAL::SetName( const char* )
+	{
+		return E_NOTIMPL;
+	}
+}
+
+#endif

--- a/trinityal/vulkan/Tr2ShaderProgramALVulkan.cpp
+++ b/trinityal/vulkan/Tr2ShaderProgramALVulkan.cpp
@@ -40,6 +40,41 @@ namespace
 			return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 		}
 	}
+
+	// RegisterType can no longer be used directly as an array index (see the two
+	// call sites in Create() below): Tr2ShaderAL.h's rewrite turned it from a dense
+	// 0-3 enum into a flag-tagged one (SRV_* = 32-42, UAV_* = 64-74), so a direct
+	// `array[registerType]` silently reads/writes far out of bounds for any SRV or
+	// UAV register. This mirrors dx12's RegisterTypeIndex
+	// (Tr2PrimaryRenderContextDx12.cpp:100) -- a RegisterType -> dense-slot mapping --
+	// sized here to the five descriptor kinds GetDescriptorType above can return:
+	// constant buffer, sampler, SRV (still coarse; splitting it is the identical bug
+	// one line away, but out of this task's scope -- see the report), UAV
+	// buffer-like, UAV image-like.
+	enum RegisterSlot
+	{
+		REGISTER_SLOT_CONSTANT_BUFFER,
+		REGISTER_SLOT_SAMPLER,
+		REGISTER_SLOT_SRV,
+		REGISTER_SLOT_UAV_BUFFER,
+		REGISTER_SLOT_UAV_IMAGE,
+		REGISTER_SLOT_COUNT
+	};
+
+	uint32_t RegisterTypeIndex( Tr2ShaderRegisterAL::RegisterType registerType )
+	{
+		if( registerType & Tr2ShaderRegisterAL::UAV_REGISTER_FLAG )
+		{
+			return registerType <= Tr2ShaderRegisterAL::UAV_STRUCTURED_BUFFER
+				? REGISTER_SLOT_UAV_BUFFER : REGISTER_SLOT_UAV_IMAGE;
+		}
+		if( registerType & Tr2ShaderRegisterAL::SRV_REGISTER_FLAG )
+		{
+			return REGISTER_SLOT_SRV;
+		}
+		return registerType == Tr2ShaderRegisterAL::SAMPLER
+			? REGISTER_SLOT_SAMPLER : REGISTER_SLOT_CONSTANT_BUFFER;
+	}
 }
 
 namespace TrinityALImpl
@@ -95,9 +130,19 @@ namespace TrinityALImpl
 		m_shaderInfo.reserve( count );
 		m_shaders.reserve( count );
 
-		uint32_t poolSizes[4] = { 0 };
+		uint32_t poolSizes[REGISTER_SLOT_COUNT] = { 0 };
+		VkDescriptorType poolTypes[REGISTER_SLOT_COUNT] = { };
 
-		uint32_t registerOffsets[] = { 0, 2, 1, 0 };
+		// One offset block (of 6*registerSize binding numbers) per slot, so registers
+		// of different kinds never collide within the same descriptor-set layout.
+		// REGISTER_SLOT_CONSTANT_BUFFER's value is unused for collision purposes --
+		// its registers land in the separate m_constantLayout, not m_resourceLayout --
+		// so it keeps the legacy CONSTANTS offset (0), same as the 2019 code.
+		// SAMPLER/SRV keep their original offsets (2/1); UAV_IMAGE keeps the original
+		// single UAV slot's offset (0 -- GetDescriptorType used to return
+		// STORAGE_IMAGE for every UAV) and the newly-distinguished UAV_BUFFER gets its
+		// own, previously-unused offset (3).
+		uint32_t registerOffsets[REGISTER_SLOT_COUNT] = { 0, 2, 1, 3, 0 };
 
 		std::vector<VkDescriptorSetLayoutBinding> resourceSetBindings, constantBindings;
 
@@ -139,8 +184,10 @@ namespace TrinityALImpl
 			auto& inputs = shaders[i].m_shader->m_signature.registers;
 			for( auto it = begin( inputs ); it != end( inputs ); ++it )
 			{
+				uint32_t slot = RegisterTypeIndex( it->registerType );
+
 				VkDescriptorSetLayoutBinding binding = {
-					it->registerIndex + registerOffsets[it->registerType] * 6 * registerSize + shaders[i].GetType() * registerSize,
+					it->registerIndex + registerOffsets[slot] * 6 * registerSize + shaders[i].GetType() * registerSize,
 					GetDescriptorType( it->registerType ),
 					1,
 					info.stage,
@@ -153,7 +200,8 @@ namespace TrinityALImpl
 				}
 				else
 				{
-					++poolSizes[it->registerType];
+					poolTypes[slot] = binding.descriptorType;
+					++poolSizes[slot];
 					resourceSetBindings.push_back( binding );
 				}
 
@@ -179,7 +227,14 @@ namespace TrinityALImpl
 				{
 					continue;
 				}
-				VkDescriptorPoolSize poolSize = { GetDescriptorType( Tr2ShaderRegisterAL::RegisterType( i ) ), poolSizes[i] };
+				// poolTypes[i] was recorded from the real registerType at tally time
+				// (above), rather than reconstructed here via GetDescriptorType(
+				// RegisterType(i) ) -- i is a synthetic slot index (see RegisterSlot),
+				// not a real RegisterType value, so casting it back would silently
+				// mis-dispatch (e.g. i == REGISTER_SLOT_UAV_BUFFER has no
+				// UAV_REGISTER_FLAG bit set and would fall through to
+				// VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE instead of STORAGE_BUFFER).
+				VkDescriptorPoolSize poolSize = { poolTypes[i], poolSizes[i] };
 				m_poolSizes.push_back( poolSize );
 			}
 		}
@@ -201,7 +256,14 @@ namespace TrinityALImpl
 				{
 					continue;
 				}
-				VkDescriptorPoolSize poolSize = { GetDescriptorType( Tr2ShaderRegisterAL::RegisterType( i ) ), poolSizes[i] };
+				// poolTypes[i] was recorded from the real registerType at tally time
+				// (above), rather than reconstructed here via GetDescriptorType(
+				// RegisterType(i) ) -- i is a synthetic slot index (see RegisterSlot),
+				// not a real RegisterType value, so casting it back would silently
+				// mis-dispatch (e.g. i == REGISTER_SLOT_UAV_BUFFER has no
+				// UAV_REGISTER_FLAG bit set and would fall through to
+				// VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE instead of STORAGE_BUFFER).
+				VkDescriptorPoolSize poolSize = { poolTypes[i], poolSizes[i] };
 				m_poolSizes.push_back( poolSize );
 			}
 		}

--- a/trinityal/vulkan/Tr2ShaderProgramALVulkan.cpp
+++ b/trinityal/vulkan/Tr2ShaderProgramALVulkan.cpp
@@ -17,13 +17,26 @@ namespace
 	{
 		switch( registerType )
 		{
-		case Tr2ShaderRegisterAL::CONSTANTS:
+		case Tr2ShaderRegisterAL::CONSTANT_BUFFER:
 			return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
 		case Tr2ShaderRegisterAL::SAMPLER:
 			return VK_DESCRIPTOR_TYPE_SAMPLER;
-		case Tr2ShaderRegisterAL::UAV:
-			return VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
 		default:
+			// UAV is no longer a single value (Tr2ShaderAL.h:56-86): it is a family
+			// flagged by UAV_REGISTER_FLAG, spanning UAV_BUFFER (64) through
+			// UAV_TEXTURECUBEARRAY (74). Vulkan's VkDescriptorType genuinely
+			// distinguishes storage buffer from storage image, so the two-way split
+			// below -- mirroring dx12's ordinal comparison against *_STRUCTURED_BUFFER,
+			// e.g. Tr2ResourceSetALDx12.cpp:128,186 -- is required for correctness, not
+			// just to compile: the old code collapsed every UAV subtype to
+			// STORAGE_IMAGE, which is wrong for UAV_BUFFER/UAV_STRUCTURED_BUFFER and is
+			// already exercised by tests/Compute.cpp.
+			if( registerType & Tr2ShaderRegisterAL::UAV_REGISTER_FLAG )
+			{
+				return registerType <= Tr2ShaderRegisterAL::UAV_STRUCTURED_BUFFER
+					? VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
+					: VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+			}
 			return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 		}
 	}
@@ -134,7 +147,7 @@ namespace TrinityALImpl
 					nullptr
 				};
 
-				if( it->registerType == Tr2ShaderRegisterAL::CONSTANTS )
+				if( it->registerType == Tr2ShaderRegisterAL::CONSTANT_BUFFER )
 				{
 					constantBindings.push_back( binding );
 				}

--- a/trinityal/vulkan/Tr2ShaderProgramALVulkan.cpp
+++ b/trinityal/vulkan/Tr2ShaderProgramALVulkan.cpp
@@ -5,6 +5,7 @@
 #include "Tr2ShaderProgramALVulkan.h"
 #include "Tr2PrimaryRenderContextVulkan.h"
 #include "Tr2ShaderALVulkan.h"
+#include "Tr2ShaderBindingABIVulkan.h"
 #include "UtilitiesVulkan.h"
 
 
@@ -116,44 +117,13 @@ namespace
 			? REGISTER_SLOT_SAMPLER : REGISTER_SLOT_CONSTANT_BUFFER;
 	}
 
-	// The binding-number block a register lives in. This is a shader-compiler ABI,
-	// NOT a private numbering scheme: the four blocks are the four HLSL register
-	// classes b/s/t/u, and Shaders.vulkan/ is compiled with dxc -fvk-{b,s,t,u}-shift
-	// arguments computed from exactly these values (see trinityal/tests/CMakeLists.txt).
-	// The values are 2019's, restored: b=0, s=2, t=1, u=0.
-	//
-	// This is deliberately NOT the same mapping as RegisterTypeIndex above. That one
-	// answers "which descriptor kind", which Vulkan splits six ways; this one answers
-	// "which binding block", which HLSL splits four ways. Tasks 4e and 4f used one
-	// index for both roles and silently moved every SRV/UAV binding number as a side
-	// effect of a descriptor-type fix -- a compute u0 went from 64 to 640. A t0 is a
-	// Buffer<> or a Texture2D<> and never both, so the type split never needed a
-	// block split to avoid collisions.
-	//
-	// b and u sharing block 0 is safe: CONSTANT_BUFFER registers go into
-	// m_constantLayout (descriptor set 0) and every other register into
-	// m_resourceLayout (set 1), so the two never share a set.
-	enum RegisterClass
-	{
-		REGISTER_CLASS_CONSTANT_BUFFER = 0,   // b
-		REGISTER_CLASS_SRV             = 1,   // t
-		REGISTER_CLASS_SAMPLER         = 2,   // s
-		REGISTER_CLASS_UAV             = 0    // u
-	};
-
-	uint32_t RegisterClassOffset( Tr2ShaderRegisterAL::RegisterType registerType )
-	{
-		if( registerType & Tr2ShaderRegisterAL::UAV_REGISTER_FLAG )
-		{
-			return REGISTER_CLASS_UAV;
-		}
-		if( registerType & Tr2ShaderRegisterAL::SRV_REGISTER_FLAG )
-		{
-			return REGISTER_CLASS_SRV;
-		}
-		return registerType == Tr2ShaderRegisterAL::SAMPLER
-			? REGISTER_CLASS_SAMPLER : REGISTER_CLASS_CONSTANT_BUFFER;
-	}
+	// The binding-number block a register lives in -- RegisterClassOffset, and the
+	// whole binding formula with it -- now lives in Tr2ShaderBindingABIVulkan.h, so
+	// that trinityal/tests/ShaderBindingABI.cpp can derive its expected SPIR-V
+	// decorations by calling the same code this file calls, instead of tabulating
+	// sixteen expected numbers that would keep passing while the formula drifted.
+	// That header carries the full rationale (four HLSL classes vs. six descriptor
+	// kinds; why b and u can share block 0; what Tasks 4e and 4f got wrong).
 }
 
 namespace TrinityALImpl
@@ -247,15 +217,13 @@ namespace TrinityALImpl
 			m_shaderInfo.push_back( info );
 			m_shaders.push_back( shaders[i] );
 
-			uint32_t registerSize = 32;
-
 			auto& inputs = shaders[i].m_shader->m_signature.registers;
 			for( auto it = begin( inputs ); it != end( inputs ); ++it )
 			{
 				uint32_t slot = RegisterTypeIndex( it->registerType );
 
 				VkDescriptorSetLayoutBinding binding = {
-					it->registerIndex + RegisterClassOffset( it->registerType ) * 6 * registerSize + shaders[i].GetType() * registerSize,
+					Tr2VulkanBindingABI::BindingNumber( it->registerType, it->registerIndex, shaders[i].GetType() ),
 					GetDescriptorType( it->registerType ),
 					1,
 					info.stage,

--- a/trinityal/vulkan/Tr2ShaderProgramALVulkan.cpp
+++ b/trinityal/vulkan/Tr2ShaderProgramALVulkan.cpp
@@ -59,6 +59,16 @@ namespace
 			// no VkBufferView machinery today (there is none anywhere under
 			// trinityal/vulkan), so STORAGE_BUFFER needs no new plumbing where
 			// UNIFORM_TEXEL_BUFFER would. Hence: STORAGE_BUFFER, mirroring UAV exactly.
+			//
+			// KNOWN WRONG, left in place deliberately for Phase 2a. HLSL Buffer<T>
+			// compiles to a uniform texel buffer and RWBuffer<T> to a storage texel
+			// buffer (verified: OpTypeImage ... Buffer, Sampled=1 and Sampled=2), so
+			// SRV_BUFFER/UAV_BUFFER want UNIFORM_TEXEL_BUFFER/STORAGE_TEXEL_BUFFER and
+			// a VkBufferView, while *_STRUCTURED_BUFFER wants STORAGE_BUFFER and a
+			// VkDescriptorBufferInfo. Neither path exists in this backend. Fixing the
+			// type here without the write path would only move the mismatch, which is
+			// how the SRV_BUFFER layout/write mismatch was created in the first place.
+			// Phase 2b owns this; Phase 2a measures it.
 			if( registerType & Tr2ShaderRegisterAL::SRV_REGISTER_FLAG )
 			{
 				return registerType <= Tr2ShaderRegisterAL::SRV_STRUCTURED_BUFFER
@@ -78,6 +88,7 @@ namespace
 	// sized here to the six descriptor kinds GetDescriptorType above can return:
 	// constant buffer, sampler, SRV buffer-like, SRV image-like, UAV buffer-like,
 	// UAV image-like.
+	// This mapping is descriptor-kind only; binding-number blocks are RegisterClassOffset's job.
 	enum RegisterSlot
 	{
 		REGISTER_SLOT_CONSTANT_BUFFER,
@@ -103,6 +114,45 @@ namespace
 		}
 		return registerType == Tr2ShaderRegisterAL::SAMPLER
 			? REGISTER_SLOT_SAMPLER : REGISTER_SLOT_CONSTANT_BUFFER;
+	}
+
+	// The binding-number block a register lives in. This is a shader-compiler ABI,
+	// NOT a private numbering scheme: the four blocks are the four HLSL register
+	// classes b/s/t/u, and Shaders.vulkan/ is compiled with dxc -fvk-{b,s,t,u}-shift
+	// arguments computed from exactly these values (see trinityal/tests/CMakeLists.txt).
+	// The values are 2019's, restored: b=0, s=2, t=1, u=0.
+	//
+	// This is deliberately NOT the same mapping as RegisterTypeIndex above. That one
+	// answers "which descriptor kind", which Vulkan splits six ways; this one answers
+	// "which binding block", which HLSL splits four ways. Tasks 4e and 4f used one
+	// index for both roles and silently moved every SRV/UAV binding number as a side
+	// effect of a descriptor-type fix -- a compute u0 went from 64 to 640. A t0 is a
+	// Buffer<> or a Texture2D<> and never both, so the type split never needed a
+	// block split to avoid collisions.
+	//
+	// b and u sharing block 0 is safe: CONSTANT_BUFFER registers go into
+	// m_constantLayout (descriptor set 0) and every other register into
+	// m_resourceLayout (set 1), so the two never share a set.
+	enum RegisterClass
+	{
+		REGISTER_CLASS_CONSTANT_BUFFER = 0,   // b
+		REGISTER_CLASS_SRV             = 1,   // t
+		REGISTER_CLASS_SAMPLER         = 2,   // s
+		REGISTER_CLASS_UAV             = 0    // u
+	};
+
+	uint32_t RegisterClassOffset( Tr2ShaderRegisterAL::RegisterType registerType )
+	{
+		if( registerType & Tr2ShaderRegisterAL::UAV_REGISTER_FLAG )
+		{
+			return REGISTER_CLASS_UAV;
+		}
+		if( registerType & Tr2ShaderRegisterAL::SRV_REGISTER_FLAG )
+		{
+			return REGISTER_CLASS_SRV;
+		}
+		return registerType == Tr2ShaderRegisterAL::SAMPLER
+			? REGISTER_CLASS_SAMPLER : REGISTER_CLASS_CONSTANT_BUFFER;
 	}
 }
 
@@ -162,21 +212,6 @@ namespace TrinityALImpl
 		uint32_t poolSizes[REGISTER_SLOT_COUNT] = { 0 };
 		VkDescriptorType poolTypes[REGISTER_SLOT_COUNT] = { };
 
-		// One offset block (of 6*registerSize binding numbers) per slot, so registers
-		// of different kinds never collide within the same descriptor-set layout.
-		// REGISTER_SLOT_CONSTANT_BUFFER's value is unused for collision purposes --
-		// its registers land in the separate m_constantLayout, not m_resourceLayout --
-		// so it keeps the legacy CONSTANTS offset (0), same as the 2019 code.
-		// SAMPLER keeps its original offset (2). SRV_IMAGE keeps the offset the
-		// single coarse SRV slot used before Task 4f split the family (1 -- every SRV
-		// subtype shared this offset); the newly-distinguished SRV_BUFFER gets its
-		// own, previously-unused offset (4). UAV_IMAGE keeps the original single UAV
-		// slot's offset (0 -- GetDescriptorType used to return STORAGE_IMAGE for
-		// every UAV) and UAV_BUFFER keeps the previously-unused offset Task 4e gave
-		// it (3). {0,1,2,3} were all already spoken for by the time Task 4f ran, so
-		// SRV_BUFFER is the only slot needing a fresh value.
-		uint32_t registerOffsets[REGISTER_SLOT_COUNT] = { 0, 2, 4, 1, 3, 0 };
-
 		std::vector<VkDescriptorSetLayoutBinding> resourceSetBindings, constantBindings;
 
 		for( size_t i = 0; i < count; ++i )
@@ -220,7 +255,7 @@ namespace TrinityALImpl
 				uint32_t slot = RegisterTypeIndex( it->registerType );
 
 				VkDescriptorSetLayoutBinding binding = {
-					it->registerIndex + registerOffsets[slot] * 6 * registerSize + shaders[i].GetType() * registerSize,
+					it->registerIndex + RegisterClassOffset( it->registerType ) * 6 * registerSize + shaders[i].GetType() * registerSize,
 					GetDescriptorType( it->registerType ),
 					1,
 					info.stage,

--- a/trinityal/vulkan/Tr2ShaderProgramALVulkan.cpp
+++ b/trinityal/vulkan/Tr2ShaderProgramALVulkan.cpp
@@ -286,6 +286,16 @@ namespace TrinityALImpl
 
 			m_constantLayout = layout;
 
+			// KNOWN PRE-EXISTING BUG, NOT FIXED HERE -- Phase 2b owns it. This loop walks
+			// the same `poolSizes` array the resource loop above already walked, and
+			// constants are deliberately excluded from that tally (see the `else` branch
+			// where poolSizes is incremented), so this emits a duplicate copy of every
+			// *resource* pool size and never emits a VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
+			// size at all. It has been wrong this way since 2019. The comment below
+			// explains only why the poolTypes[i] *lookup* is correct; it is not a claim
+			// that iterating this array here is intentional. Do not re-derive the bug --
+			// it is on the Phase 2b list with the rest of the constants write path (there
+			// is no write path to m_constantLayout at all today).
 			for( uint32_t i = 0; i < _countof( poolSizes ); ++i )
 			{
 				if( !poolSizes[i] )

--- a/trinityal/vulkan/Tr2ShaderProgramALVulkan.cpp
+++ b/trinityal/vulkan/Tr2ShaderProgramALVulkan.cpp
@@ -23,98 +23,39 @@ namespace
 		case Tr2ShaderRegisterAL::SAMPLER:
 			return VK_DESCRIPTOR_TYPE_SAMPLER;
 		default:
-			// UAV is no longer a single value (Tr2ShaderAL.h:56-86): it is a family
-			// flagged by UAV_REGISTER_FLAG, spanning UAV_BUFFER (64) through
-			// UAV_TEXTURECUBEARRAY (74). Vulkan's VkDescriptorType genuinely
-			// distinguishes storage buffer from storage image, so the two-way split
-			// below -- mirroring dx12's ordinal comparison against *_STRUCTURED_BUFFER,
-			// e.g. Tr2ResourceSetALDx12.cpp:128,186 -- is required for correctness, not
-			// just to compile: the old code collapsed every UAV subtype to
-			// STORAGE_IMAGE, which is wrong for UAV_BUFFER/UAV_STRUCTURED_BUFFER and is
-			// already exercised by tests/Compute.cpp.
+			// HLSL Buffer<T> compiles to a uniform texel buffer and RWBuffer<T> to a
+			// storage texel buffer (verified from dxc SPIR-V: OpTypeImage ... Buffer,
+			// Sampled=1 and Sampled=2), so the typed UAV register takes a texel
+			// descriptor + VkBufferView, while UAV_STRUCTURED_BUFFER takes a
+			// STORAGE_BUFFER + VkDescriptorBufferInfo. Textures take STORAGE_IMAGE.
 			if( registerType & Tr2ShaderRegisterAL::UAV_REGISTER_FLAG )
 			{
-				return registerType <= Tr2ShaderRegisterAL::UAV_STRUCTURED_BUFFER
-					? VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
-					: VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+				if( registerType == Tr2ShaderRegisterAL::UAV_BUFFER )
+				{
+					return VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
+				}
+				if( registerType == Tr2ShaderRegisterAL::UAV_STRUCTURED_BUFFER )
+				{
+					return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+				}
+				return VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
 			}
-			// SRV has the identical shape (Tr2ShaderAL.h:63-73): a family flagged by
-			// SRV_REGISTER_FLAG, spanning SRV_BUFFER (32) through SRV_TEXTURECUBEARRAY
-			// (42). The 2019 code collapsed every SRV subtype to SAMPLED_IMAGE right
-			// here via this same `default:` branch -- wrong for
-			// SRV_BUFFER/SRV_STRUCTURED_BUFFER for the identical reason as UAV above.
-			// It escaped Task 4e only because `default:` draws no compiler diagnostic;
-			// fixed now (Task 4f) with the same two-way split, the same dx12 ordinal
-			// comparison against *_STRUCTURED_BUFFER (e.g. Tr2ResourceSetALDx12.cpp:128).
-			//
-			// STORAGE_BUFFER, not UNIFORM_TEXEL_BUFFER, for the buffer-like half:
-			// metal binds SRV_BUFFER/SRV_STRUCTURED_BUFFER exactly like
-			// UAV_BUFFER/UAV_STRUCTURED_BUFFER -- a raw GPU buffer address, no
-			// format/texel-view step (Tr2ShaderALMetal.mm:69-75 vs :139-144;
-			// MetalWorkQueue.mm:3113-3125 reads gpuAddress+offset for both families the
-			// same way). dx12's typed-vs-structured buffer SRV/UAV split
-			// (Tr2BufferALDx12.cpp:158-177) is driven by the bound buffer's pixel
-			// format *at creation time*, not by which RegisterType the shader declared,
-			// so it can't be mirrored here anyway -- GetDescriptorType only ever sees
-			// the registerType, never the runtime resource. And Tr2BufferALVulkan has
-			// no VkBufferView machinery today (there is none anywhere under
-			// trinityal/vulkan), so STORAGE_BUFFER needs no new plumbing where
-			// UNIFORM_TEXEL_BUFFER would. Hence: STORAGE_BUFFER, mirroring UAV exactly.
-			//
-			// KNOWN WRONG, left in place deliberately for Phase 2a. HLSL Buffer<T>
-			// compiles to a uniform texel buffer and RWBuffer<T> to a storage texel
-			// buffer (verified: OpTypeImage ... Buffer, Sampled=1 and Sampled=2), so
-			// SRV_BUFFER/UAV_BUFFER want UNIFORM_TEXEL_BUFFER/STORAGE_TEXEL_BUFFER and
-			// a VkBufferView, while *_STRUCTURED_BUFFER wants STORAGE_BUFFER and a
-			// VkDescriptorBufferInfo. Neither path exists in this backend. Fixing the
-			// type here without the write path would only move the mismatch, which is
-			// how the SRV_BUFFER layout/write mismatch was created in the first place.
-			// Phase 2b owns this; Phase 2a measures it.
+			// The SRV mirror of the above: typed SRV_BUFFER is a uniform texel buffer,
+			// SRV_STRUCTURED_BUFFER is a storage buffer, textures are sampled images.
 			if( registerType & Tr2ShaderRegisterAL::SRV_REGISTER_FLAG )
 			{
-				return registerType <= Tr2ShaderRegisterAL::SRV_STRUCTURED_BUFFER
-					? VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
-					: VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+				if( registerType == Tr2ShaderRegisterAL::SRV_BUFFER )
+				{
+					return VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+				}
+				if( registerType == Tr2ShaderRegisterAL::SRV_STRUCTURED_BUFFER )
+				{
+					return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+				}
+				return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 			}
 			return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 		}
-	}
-
-	// RegisterType can no longer be used directly as an array index (see the two
-	// call sites in Create() below): Tr2ShaderAL.h's rewrite turned it from a dense
-	// 0-3 enum into a flag-tagged one (SRV_* = 32-42, UAV_* = 64-74), so a direct
-	// `array[registerType]` silently reads/writes far out of bounds for any SRV or
-	// UAV register. This mirrors dx12's RegisterTypeIndex
-	// (Tr2PrimaryRenderContextDx12.cpp:100) -- a RegisterType -> dense-slot mapping --
-	// sized here to the six descriptor kinds GetDescriptorType above can return:
-	// constant buffer, sampler, SRV buffer-like, SRV image-like, UAV buffer-like,
-	// UAV image-like.
-	// This mapping is descriptor-kind only; binding-number blocks are RegisterClassOffset's job.
-	enum RegisterSlot
-	{
-		REGISTER_SLOT_CONSTANT_BUFFER,
-		REGISTER_SLOT_SAMPLER,
-		REGISTER_SLOT_SRV_BUFFER,
-		REGISTER_SLOT_SRV_IMAGE,
-		REGISTER_SLOT_UAV_BUFFER,
-		REGISTER_SLOT_UAV_IMAGE,
-		REGISTER_SLOT_COUNT
-	};
-
-	uint32_t RegisterTypeIndex( Tr2ShaderRegisterAL::RegisterType registerType )
-	{
-		if( registerType & Tr2ShaderRegisterAL::UAV_REGISTER_FLAG )
-		{
-			return registerType <= Tr2ShaderRegisterAL::UAV_STRUCTURED_BUFFER
-				? REGISTER_SLOT_UAV_BUFFER : REGISTER_SLOT_UAV_IMAGE;
-		}
-		if( registerType & Tr2ShaderRegisterAL::SRV_REGISTER_FLAG )
-		{
-			return registerType <= Tr2ShaderRegisterAL::SRV_STRUCTURED_BUFFER
-				? REGISTER_SLOT_SRV_BUFFER : REGISTER_SLOT_SRV_IMAGE;
-		}
-		return registerType == Tr2ShaderRegisterAL::SAMPLER
-			? REGISTER_SLOT_SAMPLER : REGISTER_SLOT_CONSTANT_BUFFER;
 	}
 
 	// The binding-number block a register lives in -- RegisterClassOffset, and the
@@ -179,8 +120,7 @@ namespace TrinityALImpl
 		m_shaderInfo.reserve( count );
 		m_shaders.reserve( count );
 
-		uint32_t poolSizes[REGISTER_SLOT_COUNT] = { 0 };
-		VkDescriptorType poolTypes[REGISTER_SLOT_COUNT] = { };
+		std::map<VkDescriptorType, uint32_t> poolCounts;
 
 		std::vector<VkDescriptorSetLayoutBinding> resourceSetBindings, constantBindings;
 
@@ -220,8 +160,6 @@ namespace TrinityALImpl
 			auto& inputs = shaders[i].m_shader->m_signature.registers;
 			for( auto it = begin( inputs ); it != end( inputs ); ++it )
 			{
-				uint32_t slot = RegisterTypeIndex( it->registerType );
-
 				VkDescriptorSetLayoutBinding binding = {
 					Tr2VulkanBindingABI::BindingNumber( it->registerType, it->registerIndex, shaders[i].GetType() ),
 					GetDescriptorType( it->registerType ),
@@ -236,8 +174,7 @@ namespace TrinityALImpl
 				}
 				else
 				{
-					poolTypes[slot] = binding.descriptorType;
-					++poolSizes[slot];
+					++poolCounts[binding.descriptorType];
 					resourceSetBindings.push_back( binding );
 				}
 
@@ -256,23 +193,6 @@ namespace TrinityALImpl
 			CR_RETURN_HR( Vk2Al( vkCreateDescriptorSetLayout( renderContext.m_device, &layoutInfo, nullptr, &layout ) ) );
 
 			m_resourceLayout = layout;
-
-			for( uint32_t i = 0; i < _countof( poolSizes ); ++i )
-			{
-				if( !poolSizes[i] )
-				{
-					continue;
-				}
-				// poolTypes[i] was recorded from the real registerType at tally time
-				// (above), rather than reconstructed here via GetDescriptorType(
-				// RegisterType(i) ) -- i is a synthetic slot index (see RegisterSlot),
-				// not a real RegisterType value, so casting it back would silently
-				// mis-dispatch (e.g. i == REGISTER_SLOT_UAV_BUFFER has no
-				// UAV_REGISTER_FLAG bit set and would fall through to
-				// VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE instead of STORAGE_BUFFER).
-				VkDescriptorPoolSize poolSize = { poolTypes[i], poolSizes[i] };
-				m_poolSizes.push_back( poolSize );
-			}
 		}
 
 		if( !constantBindings.empty() )
@@ -285,33 +205,18 @@ namespace TrinityALImpl
 			CR_RETURN_HR( Vk2Al( vkCreateDescriptorSetLayout( renderContext.m_device, &layoutInfo, nullptr, &layout ) ) );
 
 			m_constantLayout = layout;
+		}
 
-			// KNOWN PRE-EXISTING BUG, NOT FIXED HERE -- Phase 2b owns it. This loop walks
-			// the same `poolSizes` array the resource loop above already walked, and
-			// constants are deliberately excluded from that tally (see the `else` branch
-			// where poolSizes is incremented), so this emits a duplicate copy of every
-			// *resource* pool size and never emits a VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
-			// size at all. It has been wrong this way since 2019. The comment below
-			// explains only why the poolTypes[i] *lookup* is correct; it is not a claim
-			// that iterating this array here is intentional. Do not re-derive the bug --
-			// it is on the Phase 2b list with the rest of the constants write path (there
-			// is no write path to m_constantLayout at all today).
-			for( uint32_t i = 0; i < _countof( poolSizes ); ++i )
-			{
-				if( !poolSizes[i] )
-				{
-					continue;
-				}
-				// poolTypes[i] was recorded from the real registerType at tally time
-				// (above), rather than reconstructed here via GetDescriptorType(
-				// RegisterType(i) ) -- i is a synthetic slot index (see RegisterSlot),
-				// not a real RegisterType value, so casting it back would silently
-				// mis-dispatch (e.g. i == REGISTER_SLOT_UAV_BUFFER has no
-				// UAV_REGISTER_FLAG bit set and would fall through to
-				// VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE instead of STORAGE_BUFFER).
-				VkDescriptorPoolSize poolSize = { poolTypes[i], poolSizes[i] };
-				m_poolSizes.push_back( poolSize );
-			}
+		// The descriptor pool carries one size entry per distinct VkDescriptorType.
+		// poolCounts was tallied from each register's real descriptor type, so typed
+		// and structured buffers land in distinct entries rather than being collapsed
+		// (the pre-Phase-2b code both collapsed SRV/UAV buffer types and then emitted
+		// duplicate entries from the resource array twice). Constants are excluded
+		// here -- their write path (descriptor set 0) is separate and comes later.
+		for( auto it = begin( poolCounts ); it != end( poolCounts ); ++it )
+		{
+			VkDescriptorPoolSize poolSize = { it->first, it->second };
+			m_poolSizes.push_back( poolSize );
 		}
 
 		uint32_t size = 0;

--- a/trinityal/vulkan/Tr2ShaderProgramALVulkan.cpp
+++ b/trinityal/vulkan/Tr2ShaderProgramALVulkan.cpp
@@ -37,6 +37,34 @@ namespace
 					? VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
 					: VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
 			}
+			// SRV has the identical shape (Tr2ShaderAL.h:63-73): a family flagged by
+			// SRV_REGISTER_FLAG, spanning SRV_BUFFER (32) through SRV_TEXTURECUBEARRAY
+			// (42). The 2019 code collapsed every SRV subtype to SAMPLED_IMAGE right
+			// here via this same `default:` branch -- wrong for
+			// SRV_BUFFER/SRV_STRUCTURED_BUFFER for the identical reason as UAV above.
+			// It escaped Task 4e only because `default:` draws no compiler diagnostic;
+			// fixed now (Task 4f) with the same two-way split, the same dx12 ordinal
+			// comparison against *_STRUCTURED_BUFFER (e.g. Tr2ResourceSetALDx12.cpp:128).
+			//
+			// STORAGE_BUFFER, not UNIFORM_TEXEL_BUFFER, for the buffer-like half:
+			// metal binds SRV_BUFFER/SRV_STRUCTURED_BUFFER exactly like
+			// UAV_BUFFER/UAV_STRUCTURED_BUFFER -- a raw GPU buffer address, no
+			// format/texel-view step (Tr2ShaderALMetal.mm:69-75 vs :139-144;
+			// MetalWorkQueue.mm:3113-3125 reads gpuAddress+offset for both families the
+			// same way). dx12's typed-vs-structured buffer SRV/UAV split
+			// (Tr2BufferALDx12.cpp:158-177) is driven by the bound buffer's pixel
+			// format *at creation time*, not by which RegisterType the shader declared,
+			// so it can't be mirrored here anyway -- GetDescriptorType only ever sees
+			// the registerType, never the runtime resource. And Tr2BufferALVulkan has
+			// no VkBufferView machinery today (there is none anywhere under
+			// trinityal/vulkan), so STORAGE_BUFFER needs no new plumbing where
+			// UNIFORM_TEXEL_BUFFER would. Hence: STORAGE_BUFFER, mirroring UAV exactly.
+			if( registerType & Tr2ShaderRegisterAL::SRV_REGISTER_FLAG )
+			{
+				return registerType <= Tr2ShaderRegisterAL::SRV_STRUCTURED_BUFFER
+					? VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
+					: VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+			}
 			return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 		}
 	}
@@ -47,15 +75,15 @@ namespace
 	// `array[registerType]` silently reads/writes far out of bounds for any SRV or
 	// UAV register. This mirrors dx12's RegisterTypeIndex
 	// (Tr2PrimaryRenderContextDx12.cpp:100) -- a RegisterType -> dense-slot mapping --
-	// sized here to the five descriptor kinds GetDescriptorType above can return:
-	// constant buffer, sampler, SRV (still coarse; splitting it is the identical bug
-	// one line away, but out of this task's scope -- see the report), UAV
-	// buffer-like, UAV image-like.
+	// sized here to the six descriptor kinds GetDescriptorType above can return:
+	// constant buffer, sampler, SRV buffer-like, SRV image-like, UAV buffer-like,
+	// UAV image-like.
 	enum RegisterSlot
 	{
 		REGISTER_SLOT_CONSTANT_BUFFER,
 		REGISTER_SLOT_SAMPLER,
-		REGISTER_SLOT_SRV,
+		REGISTER_SLOT_SRV_BUFFER,
+		REGISTER_SLOT_SRV_IMAGE,
 		REGISTER_SLOT_UAV_BUFFER,
 		REGISTER_SLOT_UAV_IMAGE,
 		REGISTER_SLOT_COUNT
@@ -70,7 +98,8 @@ namespace
 		}
 		if( registerType & Tr2ShaderRegisterAL::SRV_REGISTER_FLAG )
 		{
-			return REGISTER_SLOT_SRV;
+			return registerType <= Tr2ShaderRegisterAL::SRV_STRUCTURED_BUFFER
+				? REGISTER_SLOT_SRV_BUFFER : REGISTER_SLOT_SRV_IMAGE;
 		}
 		return registerType == Tr2ShaderRegisterAL::SAMPLER
 			? REGISTER_SLOT_SAMPLER : REGISTER_SLOT_CONSTANT_BUFFER;
@@ -138,11 +167,15 @@ namespace TrinityALImpl
 		// REGISTER_SLOT_CONSTANT_BUFFER's value is unused for collision purposes --
 		// its registers land in the separate m_constantLayout, not m_resourceLayout --
 		// so it keeps the legacy CONSTANTS offset (0), same as the 2019 code.
-		// SAMPLER/SRV keep their original offsets (2/1); UAV_IMAGE keeps the original
-		// single UAV slot's offset (0 -- GetDescriptorType used to return
-		// STORAGE_IMAGE for every UAV) and the newly-distinguished UAV_BUFFER gets its
-		// own, previously-unused offset (3).
-		uint32_t registerOffsets[REGISTER_SLOT_COUNT] = { 0, 2, 1, 3, 0 };
+		// SAMPLER keeps its original offset (2). SRV_IMAGE keeps the offset the
+		// single coarse SRV slot used before Task 4f split the family (1 -- every SRV
+		// subtype shared this offset); the newly-distinguished SRV_BUFFER gets its
+		// own, previously-unused offset (4). UAV_IMAGE keeps the original single UAV
+		// slot's offset (0 -- GetDescriptorType used to return STORAGE_IMAGE for
+		// every UAV) and UAV_BUFFER keeps the previously-unused offset Task 4e gave
+		// it (3). {0,1,2,3} were all already spoken for by the time Task 4f ran, so
+		// SRV_BUFFER is the only slot needing a fresh value.
+		uint32_t registerOffsets[REGISTER_SLOT_COUNT] = { 0, 2, 4, 1, 3, 0 };
 
 		std::vector<VkDescriptorSetLayoutBinding> resourceSetBindings, constantBindings;
 

--- a/trinityal/vulkan/Tr2ShaderProgramALVulkan.h
+++ b/trinityal/vulkan/Tr2ShaderProgramALVulkan.h
@@ -1,0 +1,62 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   February 2019
+//    Copyright: CCP 2019
+//
+
+#pragma once
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "../include/Tr2ShaderProgramAL.h"
+#include "../include/Tr2ShaderAL.h"
+#include "../include/Tr2ResourceSetAL.h"
+
+namespace TrinityALImpl
+{
+	class Tr2ShaderProgramAL : public Tr2DeviceResourceAL<Tr2ShaderProgramAL>
+	{
+	public:
+		Tr2ShaderProgramAL();
+		~Tr2ShaderProgramAL();
+
+		ALResult Create( ::Tr2ShaderAL* shaders, size_t count, Tr2PrimaryRenderContextAL& renderContext );
+		void Destroy();
+		bool IsValid() const;
+		const Tr2RegisterMapAL& GetRegisterMap() const;
+
+		Tr2ALMemoryType GetMemoryClass() const;
+		void Describe( Tr2DeviceResourceDescriptionAL& description ) const;
+		ALResult SetName( const char* name );
+
+	private:
+		std::vector<VkPipelineShaderStageCreateInfo> m_shaderInfo;
+		std::vector<::Tr2ShaderAL> m_shaders;
+		std::vector<Tr2ShaderPipelineInputAL> m_shaderInputs;
+
+		std::vector<VkDescriptorPoolSize> m_poolSizes;
+
+		VkPipelineLayout m_pipelineLayout;
+
+		VkDescriptorSetLayout m_resourceLayout;
+		VkDescriptorSetLayout m_constantLayout;
+
+		//std::vector<VkDescriptorSetLayout> m_layouts;
+		Tr2PrimaryRenderContextAL* m_owner;
+
+		struct RegisterInput
+		{
+			uint32_t binding;
+			uint32_t stage;
+			uint32_t registerIndex;
+
+			Tr2ShaderRegisterAL::RegisterType type;
+		};
+		std::vector<RegisterInput> m_registerInput;
+		Tr2RegisterMapAL m_registerMap;
+
+		friend class Tr2RenderContextAL;
+		friend class TrinityALImpl::Tr2ResourceSetAL;
+	};
+}
+#endif

--- a/trinityal/vulkan/Tr2SwapChainALVulkan.h
+++ b/trinityal/vulkan/Tr2SwapChainALVulkan.h
@@ -1,0 +1,73 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   February 2019
+//    Copyright: CCP 2019
+//
+
+#pragma once
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "../include/Tr2SwapChainAL.h"
+#include "../include/Tr2TextureAL.h"
+
+
+namespace TrinityALImpl
+{
+
+	class Tr2SwapChainAL : public Tr2DeviceResourceAL<Tr2SwapChainAL>
+	{
+	public:
+		Tr2SwapChainAL()
+		{
+
+		}
+
+		ALResult Create( Tr2WindowHandle windowHandle, Tr2PrimaryRenderContextAL &renderContext )
+		{
+			return E_NOTIMPL;
+		}
+		void Destroy()
+		{
+
+		}
+
+		bool IsValid() const
+		{
+			return false;
+		}
+
+		ALResult Present( Tr2RenderContextAL& renderContext )
+		{
+			return E_NOTIMPL;
+		}
+
+		uint32_t GetWidth() const
+		{
+			return 0;
+		}
+		uint32_t GetHeight() const
+		{
+			return 0;
+		}
+
+		::Tr2TextureAL m_backBuffer;
+
+		bool operator==( const Tr2SwapChainAL& other ) const { return false; }
+
+		Tr2ALMemoryType GetMemoryClass() const { return AL_MEMORY_MANAGED; }
+		void Describe( Tr2DeviceResourceDescriptionAL& description ) const
+		{
+		}
+		ALResult SetName( const char* name )
+		{
+			return E_NOTIMPL;
+		}
+
+	private:
+		Tr2SwapChainAL( const Tr2SwapChainAL& ) /* = delete */;
+		Tr2SwapChainAL& operator=( const Tr2SwapChainAL& ) /* = delete */;
+	};
+}
+
+#endif

--- a/trinityal/vulkan/Tr2TextureALVulkan.cpp
+++ b/trinityal/vulkan/Tr2TextureALVulkan.cpp
@@ -1,0 +1,398 @@
+#include "StdAfx.h"
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "Tr2TextureALVulkan.h"
+#include "Tr2AdapterStructures.h"
+#include "Tr2PrimaryRenderContextVulkan.h"
+#include "VkResult.h"
+#include "UtilitiesVulkan.h"
+
+
+namespace
+{
+
+	ALResult CheckCreationFlags( const Tr2BitmapDimensions& desc, const Tr2MsaaDesc& msaa, Tr2GpuUsage::Type gpuUsage, Tr2CpuUsage::Type cpuUsage )
+	{
+		if( HasBufferFlags( gpuUsage ) )
+		{
+			return E_INVALIDARG;
+		}
+
+		if( msaa.samples > 1 )
+		{
+			if( HasFlag( gpuUsage, Tr2GpuUsage::UNORDERED_ACCESS ) )
+			{
+				return E_INVALIDARG;
+			}
+			if( cpuUsage != Tr2CpuUsage::NONE )
+			{
+				return E_INVALIDARG;
+			}
+			if( desc.GetType() != Tr2RenderContextEnum::TEX_TYPE_2D )
+			{
+				return E_INVALIDARG;
+			}
+		}
+		if( desc.GetType() != Tr2RenderContextEnum::TEX_TYPE_2D )
+		{
+			if( desc.GetType() == Tr2RenderContextEnum::TEX_TYPE_CUBE )
+			{
+				if( desc.GetArraySize() != 6 )
+				{
+					return E_INVALIDARG;
+				}
+			}
+			else if( desc.GetArraySize() > 1 )
+			{
+				return E_INVALIDARG;
+			}
+		}
+		if( desc.GetType() != Tr2RenderContextEnum::TEX_TYPE_2D && HasFlag( gpuUsage, Tr2GpuUsage::DEPTH_STENCIL ) )
+		{
+			return E_INVALIDARG;
+		}
+		if( msaa.samples > 1 && desc.GetTrueMipCount() > 1 )
+		{
+			return E_INVALIDARG;
+		}
+		if( HasFlag( gpuUsage, Tr2GpuUsage::RENDER_TARGET ) && HasFlag( cpuUsage, Tr2CpuUsage::WRITE ) )
+		{
+			return E_INVALIDARG;
+		}
+		if( HasFlag( gpuUsage, Tr2GpuUsage::DEPTH_STENCIL ) && cpuUsage != Tr2CpuUsage::NONE )
+		{
+			return E_INVALIDARG;
+		}
+		if( HasFlag( gpuUsage, Tr2GpuUsage::DEPTH_STENCIL ) && desc.GetTrueMipCount() > 1 )
+		{
+			return E_INVALIDARG;
+		}
+		if( desc.GetType() == Tr2RenderContextEnum::TEX_TYPE_3D && cpuUsage != Tr2CpuUsage::NONE )
+		{
+			return E_INVALIDARG;
+		}
+		if( HasFlag( cpuUsage, Tr2CpuUsage::READ ) && HasFlag( cpuUsage, Tr2CpuUsage::WRITE_OFTEN ) )
+		{
+			return E_INVALIDARG;
+		}
+		return S_OK;
+	}
+}
+
+namespace TrinityALImpl
+{
+
+	Tr2TextureAL::Tr2TextureAL()
+		:m_owner( nullptr ),
+		m_memory( VK_NULL_HANDLE ),
+		m_currentIndex( 0 ),
+		m_cpuUsage( Tr2CpuUsage::NONE ),
+		m_gpuUsage( Tr2GpuUsage::NONE ),
+		m_format( VK_FORMAT_UNDEFINED )
+	{
+	}
+
+	Tr2TextureAL::~Tr2TextureAL()
+	{
+		Destroy();
+	}
+
+	ALResult Tr2TextureAL::Create( const Tr2BitmapDimensions& desc, const Tr2MsaaDesc& msaa, Tr2GpuUsage::Type gpuUsage, Tr2CpuUsage::Type cpuUsage, Tr2SubresourceData* initialData, Tr2PrimaryRenderContextAL& renderContext )
+	{
+		Destroy();
+
+		if( !renderContext.IsValid() )
+		{
+			return E_INVALIDARG;
+		}
+
+		FORWARD_HR( CheckCreationFlags( desc, msaa, gpuUsage, cpuUsage ) );
+
+		if( !IsWritable( gpuUsage ) && !HasFlag( cpuUsage, Tr2CpuUsage::WRITE ) && !initialData )
+		{
+			return E_INVALIDARG;
+		}
+
+		VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+		if( HasFlag( gpuUsage, Tr2GpuUsage::SHADER_RESOURCE ) )
+		{
+			usage |= VK_IMAGE_USAGE_SAMPLED_BIT;
+		}
+		if( HasFlag( gpuUsage, Tr2GpuUsage::RENDER_TARGET ) )
+		{
+			usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+		}
+		if( HasFlag( gpuUsage, Tr2GpuUsage::DEPTH_STENCIL ) )
+		{
+			usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+		}
+		if( HasFlag( gpuUsage, Tr2GpuUsage::UNORDERED_ACCESS ) )
+		{
+			usage |= VK_IMAGE_USAGE_STORAGE_BIT;
+		}
+
+		VkImage image;
+		VkDeviceMemory memory;
+
+		CR_RETURN_HR( CreateImage( image, memory, desc, msaa, usage, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, renderContext ) );
+
+		VkImageViewCreateInfo image_view_create_info = {
+			VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+			nullptr,
+			0,
+			image,
+			desc.GetType() == Tr2RenderContextEnum::TEX_TYPE_3D ? VK_IMAGE_VIEW_TYPE_3D : VK_IMAGE_VIEW_TYPE_2D,
+			GetVulkanFormat( desc.GetFormat() ),
+			{
+				VK_COMPONENT_SWIZZLE_IDENTITY,
+				VK_COMPONENT_SWIZZLE_IDENTITY,
+				VK_COMPONENT_SWIZZLE_IDENTITY,
+				VK_COMPONENT_SWIZZLE_IDENTITY
+			},
+			{
+				VK_IMAGE_ASPECT_COLOR_BIT,
+				0,
+				desc.GetTrueMipCount(),
+				0,
+				desc.GetArraySize()
+			}
+		};
+
+		VkImageView imageView;
+		CR_RETURN_HR( Vk2Al( vkCreateImageView( renderContext.m_device, &image_view_create_info, nullptr, &imageView ) ) );
+
+		if( initialData )
+		{
+			std::vector<VkBufferImageCopy> copyInfo;
+			size_t index = 0;
+			size_t size = 0;
+			for( uint32_t i = 0; i < desc.GetArraySize(); ++i )
+			{
+				for( uint32_t j = 0; j < desc.GetMipCount(); ++j )
+				{
+					VkBufferImageCopy buffer_image_copy_info = {
+						size,                                  // VkDeviceSize               bufferOffset
+						initialData[index].m_sysMemPitch / Tr2RenderContextEnum::GetBytesPerPixel( desc.GetFormat() ),   // uint32_t                   bufferRowLength
+						initialData[index].m_sysMemSlicePitch / Tr2RenderContextEnum::GetBytesPerPixel( desc.GetFormat() ),                                  // uint32_t                   bufferImageHeight
+						{ VK_IMAGE_ASPECT_COLOR_BIT, j, i, 1 },
+						{ 0, 0, 0 },
+						{ desc.GetMipWidth( j ), desc.GetMipHeight( j ), desc.GetMipDepth( j ) }
+					};
+					copyInfo.push_back( buffer_image_copy_info );
+					size += initialData[index].m_sysMemSlicePitch * desc.GetMipDepth( j );
+					++index;
+				}
+			}
+
+			VkBuffer stagingBuffer;
+			VkDeviceMemory stagingMemory;
+			CreateBuffer( stagingBuffer, stagingMemory, size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, renderContext );
+
+			void *data;
+			Vk2Al( vkMapMemory( renderContext.m_device, stagingMemory, 0, size, 0, &data ) );
+
+			for( size_t i = 0; i < copyInfo.size(); ++i )
+			{
+				memcpy( static_cast<uint8_t*>( data ) + copyInfo[i].bufferOffset, initialData[i].m_sysMem, initialData[i].m_sysMemSlicePitch * copyInfo[i].imageExtent.depth );
+			}
+
+			VkMappedMemoryRange flush_range = {
+				VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,
+				nullptr,
+				stagingMemory,
+				0,
+				VK_WHOLE_SIZE
+			};
+			vkFlushMappedMemoryRanges( renderContext.m_device, 1, &flush_range );
+
+			vkUnmapMemory( renderContext.m_device, stagingMemory );
+
+
+			VkImageMemoryBarrier barrier = {
+				VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+				nullptr,
+				0,
+				VK_ACCESS_TRANSFER_WRITE_BIT,
+				VK_IMAGE_LAYOUT_UNDEFINED,
+				VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+				VK_QUEUE_FAMILY_IGNORED,
+				VK_QUEUE_FAMILY_IGNORED,
+				image,
+				{
+					VK_IMAGE_ASPECT_COLOR_BIT,
+					0,
+					desc.GetTrueMipCount(),
+					0,
+					desc.GetArraySize()
+				}
+			};
+			vkCmdPipelineBarrier( renderContext.m_commandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &barrier );
+
+			vkCmdCopyBufferToImage( renderContext.m_commandBuffer, stagingBuffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, uint32_t( copyInfo.size() ), copyInfo.data() );
+
+			barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+			barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+			barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+			barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+			vkCmdPipelineBarrier( renderContext.m_commandBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 0, nullptr, 1, &barrier );
+
+			renderContext.DestroyLaterVulkan( stagingBuffer, vkDestroyBuffer );
+			renderContext.DestroyLaterVulkan( stagingMemory, vkFreeMemory );
+		}
+
+		m_images.push_back( image );
+		m_imageViews.push_back( imageView );
+		m_memory = memory;
+		m_cpuUsage = cpuUsage;
+		m_gpuUsage = gpuUsage;
+		m_desc = desc;
+		m_msaa = msaa;
+		m_format = GetVulkanFormat( desc.GetFormat() );
+		m_owner = &renderContext;
+
+		return S_OK;
+	}
+
+	void Tr2TextureAL::Destroy()
+	{
+		if( m_owner )
+		{
+			if( m_memory )
+			{
+				m_owner->DestroyLaterVulkan( m_memory, vkFreeMemory );
+			}
+			for( auto it = begin( m_imageViews ); it != end( m_imageViews ); ++it )
+			{
+				m_owner->DestroyLaterVulkan( *it, vkDestroyImageView );
+			}
+			if( m_images.size() == 1 )
+			{
+				// don't destroy swap chain images?
+				for( auto it = begin( m_images ); it != end( m_images ); ++it )
+				{
+					m_owner->DestroyLaterVulkan( *it, vkDestroyImage );
+				}
+			}
+			m_images.clear();
+			m_imageViews.clear();
+		}
+		m_currentIndex = 0;
+		m_cpuUsage = Tr2CpuUsage::NONE;
+		m_gpuUsage = Tr2GpuUsage::NONE;
+		m_format = VK_FORMAT_UNDEFINED;
+	}
+
+	bool Tr2TextureAL::IsValid() const
+	{
+		return !m_images.empty();
+	}
+
+	Tr2ALMemoryType Tr2TextureAL::GetMemoryClass() const
+	{
+		return AL_MEMORY_MANAGED;
+	}
+
+	const Tr2BitmapDimensions& Tr2TextureAL::GetDesc() const
+	{
+		return m_desc;
+	}
+
+	const Tr2MsaaDesc& Tr2TextureAL::GetMsaaDesc() const
+	{
+		return m_msaa;
+	}
+
+	Tr2GpuUsage::Type Tr2TextureAL::GetGpuUsage() const
+	{
+		return m_gpuUsage;
+	}
+
+	Tr2CpuUsage::Type Tr2TextureAL::GetCpuUsage() const
+	{
+		return m_cpuUsage;
+	}
+
+
+	ALResult Tr2TextureAL::AssignFromSwapChainVulkan( const std::vector<VkImage>& backBuffers, const Tr2DisplayModeInfo& mode, Tr2PrimaryRenderContextAL& renderContext )
+	{
+		Destroy();
+
+		std::vector<VkImageView> views;
+		for( auto it = begin( backBuffers ); it != end( backBuffers ); ++it )
+		{
+			VkImageViewCreateInfo imageViewInfo = {
+				VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+				nullptr,
+				0,
+				*it,
+				VK_IMAGE_VIEW_TYPE_2D,
+				GetVulkanFormat( mode.format ),
+				{
+					VK_COMPONENT_SWIZZLE_IDENTITY,
+					VK_COMPONENT_SWIZZLE_IDENTITY,
+					VK_COMPONENT_SWIZZLE_IDENTITY,
+					VK_COMPONENT_SWIZZLE_IDENTITY
+				},
+				{
+					VK_IMAGE_ASPECT_COLOR_BIT,
+					0,
+					1,
+					0,
+					1
+				}
+			};
+
+			VkImageView view;
+
+			CR_RETURN_HR( Vk2Al( vkCreateImageView( renderContext.m_device, &imageViewInfo, nullptr, &view ) ) );
+			views.push_back( view );
+		}
+
+		m_images = backBuffers;
+		m_imageViews = views;
+		m_desc = Tr2BitmapDimensions( mode.width, mode.height, 1, mode.format );
+		m_msaa = Tr2MsaaDesc();
+		m_gpuUsage = Tr2GpuUsage::RENDER_TARGET;
+		m_format = GetVulkanFormat( mode.format );
+		m_owner = &renderContext;
+		return S_OK;
+	}
+
+	void Tr2TextureAL::SetCurrentImageVulkan( uint32_t index )
+	{
+		m_currentIndex = index;
+	}
+
+	VkImage Tr2TextureAL::GetImageVulkan() const
+	{
+		return m_images[m_currentIndex];
+	}
+
+	VkImageView Tr2TextureAL::GetImageView() const
+	{
+		return m_imageViews[m_currentIndex];
+	}
+
+	uint32_t Tr2TextureAL::GetSrvIndexInHeap( Tr2RenderContextEnum::ColorSpace ) const
+	{
+		return 0xffffffff;
+	}
+
+	uint32_t Tr2TextureAL::GetUavIndexInHeap( uint32_t ) const
+	{
+		return 0xffffffff;
+	}
+
+	void Tr2TextureAL::Describe( Tr2DeviceResourceDescriptionAL& description ) const
+	{
+		description["type"] = "Tr2TextureAL";
+	}
+
+	ALResult Tr2TextureAL::SetName( const char* )
+	{
+		return E_NOTIMPL;
+	}
+}
+
+#endif

--- a/trinityal/vulkan/Tr2TextureALVulkan.cpp
+++ b/trinityal/vulkan/Tr2TextureALVulkan.cpp
@@ -393,6 +393,11 @@ namespace TrinityALImpl
 	{
 		return E_NOTIMPL;
 	}
+
+	const char* Tr2TextureAL::GetName() const
+	{
+		return nullptr;
+	}
 }
 
 #endif

--- a/trinityal/vulkan/Tr2TextureALVulkan.h
+++ b/trinityal/vulkan/Tr2TextureALVulkan.h
@@ -1,0 +1,113 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   February 2019
+//    Copyright: CCP 2019
+//
+
+#pragma once
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+
+#include "../include/Tr2TextureAL.h"
+#include "../include/Tr2BitmapDimensions.h"
+#include "../Tr2HalHelperStructures.h"
+
+namespace TrinityALImpl
+{
+	class Tr2ResourceSetAL;
+}
+
+struct Tr2DisplayModeInfo;
+
+
+namespace TrinityALImpl
+{
+	class Tr2TextureAL : public Tr2DeviceResourceAL<Tr2TextureAL>
+	{
+	public:
+		Tr2TextureAL();
+		~Tr2TextureAL();
+
+		ALResult Create( const Tr2BitmapDimensions& desc, const Tr2MsaaDesc& msaa, Tr2GpuUsage::Type gpuUsage, Tr2CpuUsage::Type cpuUsage, Tr2SubresourceData* initialData, Tr2PrimaryRenderContextAL& renderContext );
+
+		ALResult OpenShared( uintptr_t handle, Tr2GpuUsage::Type gpuUsage, Tr2PrimaryRenderContextAL& renderContext )
+		{
+			return E_NOTIMPL;
+		}
+		void Destroy();
+
+		bool IsValid() const;
+		Tr2ALMemoryType GetMemoryClass() const;
+		const Tr2BitmapDimensions& GetDesc() const;
+		const Tr2MsaaDesc& GetMsaaDesc() const;
+		Tr2GpuUsage::Type GetGpuUsage() const;
+		Tr2CpuUsage::Type GetCpuUsage() const;
+
+		ALResult MapForReading( const Tr2TextureSubresource& region, const void*& data, uint32_t& pitch, Tr2RenderContextAL& renderContext )
+		{
+			return E_NOTIMPL;
+		}
+		void UnmapForReading( Tr2RenderContextAL& renderContext )
+		{
+
+		}
+		ALResult MapForWriting( const Tr2TextureSubresource& region, void*& data, uint32_t& pitch, Tr2RenderContextAL& renderContext )
+		{
+			return E_NOTIMPL;
+		}
+		void UnmapForWriting( Tr2RenderContextAL& renderContext )
+		{
+
+		}
+
+		ALResult UpdateSubresource( const Tr2TextureSubresource& region, const void* source, uint32_t pitch, uint32_t slicePitch, Tr2RenderContextAL& renderContext )
+		{
+			return E_NOTIMPL;
+		}
+		ALResult CopySubresourceRegion( const Tr2TextureSubresource& destSubresource, Tr2TextureAL& source, const Tr2TextureSubresource& sourceSubresource, Tr2RenderContextAL& renderContext )
+		{
+			return E_NOTIMPL;
+		}
+		ALResult GenerateMipMaps( Tr2RenderContextAL& renderContext )
+		{
+			return E_NOTIMPL;
+		}
+		ALResult Resolve( Tr2TextureAL& destination, Tr2RenderContextAL& renderContext )
+		{
+			return E_NOTIMPL;
+		}
+		uintptr_t GetSharedHandle() const
+		{
+			return 0;
+		}
+
+		ALResult AssignFromSwapChainVulkan( const std::vector<VkImage>& backBuffers, const Tr2DisplayModeInfo& mode, Tr2PrimaryRenderContextAL& renderContext );
+		void SetCurrentImageVulkan( uint32_t index );
+		VkImage GetImageVulkan() const;
+		VkImageView GetImageView() const;
+		void Describe( Tr2DeviceResourceDescriptionAL& description ) const;
+		ALResult SetName( const char* name );
+
+		uint32_t GetSrvIndexInHeap( Tr2RenderContextEnum::ColorSpace colorSpace = Tr2RenderContextEnum::COLOR_SPACE_LINEAR ) const;
+		uint32_t GetUavIndexInHeap( uint32_t mip ) const;
+
+	private:
+		std::vector<VkImage> m_images;
+		std::vector<VkImageView> m_imageViews;
+		VkDeviceMemory m_memory;
+		Tr2PrimaryRenderContextAL* m_owner;
+		uint32_t m_currentIndex;
+		VkFormat m_format;
+
+		Tr2BitmapDimensions m_desc;
+		Tr2MsaaDesc m_msaa;
+		Tr2CpuUsage::Type m_cpuUsage;
+		Tr2GpuUsage::Type m_gpuUsage;
+
+		friend class Tr2RenderContextAL;
+		friend class TrinityALImpl::Tr2ResourceSetAL;
+	};
+}
+
+#endif

--- a/trinityal/vulkan/Tr2TextureALVulkan.h
+++ b/trinityal/vulkan/Tr2TextureALVulkan.h
@@ -10,7 +10,6 @@
 
 
 #include "../include/Tr2TextureAL.h"
-#include "../include/Tr2BitmapDimensions.h"
 #include "../Tr2HalHelperStructures.h"
 
 namespace TrinityALImpl

--- a/trinityal/vulkan/Tr2TextureALVulkan.h
+++ b/trinityal/vulkan/Tr2TextureALVulkan.h
@@ -45,6 +45,10 @@ namespace TrinityALImpl
 
 		ALResult MapForReading( const Tr2TextureSubresource& region, const void*& data, uint32_t& pitch, Tr2RenderContextAL& renderContext )
 		{
+			return MapForReading( region, true, data, pitch, renderContext );
+		}
+		ALResult MapForReading( const Tr2TextureSubresource& region, bool synchronize, const void*& data, uint32_t& pitch, Tr2RenderContextAL& renderContext )
+		{
 			return E_NOTIMPL;
 		}
 		void UnmapForReading( Tr2RenderContextAL& renderContext )
@@ -87,6 +91,7 @@ namespace TrinityALImpl
 		VkImageView GetImageView() const;
 		void Describe( Tr2DeviceResourceDescriptionAL& description ) const;
 		ALResult SetName( const char* name );
+		const char* GetName() const;
 
 		uint32_t GetSrvIndexInHeap( Tr2RenderContextEnum::ColorSpace colorSpace = Tr2RenderContextEnum::COLOR_SPACE_LINEAR ) const;
 		uint32_t GetUavIndexInHeap( uint32_t mip ) const;

--- a/trinityal/vulkan/Tr2VertexLayoutALVulkan.cpp
+++ b/trinityal/vulkan/Tr2VertexLayoutALVulkan.cpp
@@ -1,0 +1,162 @@
+#include "StdAfx.h"
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "Tr2VertexLayoutALVulkan.h"
+
+namespace
+{
+	VkFormat GetFormat( Tr2VertexDefinition::DataType vertexType )
+	{
+#define VD_CASE(x,y) case Tr2VertexDefinition::x : return y;
+		switch( vertexType )
+		{
+			VD_CASE( BYTE_1, VK_FORMAT_R8_SINT );
+			VD_CASE( BYTE_2, VK_FORMAT_R8G8_SINT );
+			VD_CASE( BYTE_3, VK_FORMAT_R8G8B8_SINT );
+			VD_CASE( BYTE_4, VK_FORMAT_R8G8B8A8_SINT );
+
+			VD_CASE( UBYTE_1, VK_FORMAT_R8_UINT );
+			VD_CASE( UBYTE_2, VK_FORMAT_R8G8_UINT );
+			VD_CASE( UBYTE_3, VK_FORMAT_R8G8B8_UINT );
+			VD_CASE( UBYTE_4, VK_FORMAT_R8G8B8A8_UINT );
+
+
+			VD_CASE( BYTE_1_NORM, VK_FORMAT_R8_SNORM );
+			VD_CASE( BYTE_2_NORM, VK_FORMAT_R8G8_SNORM );
+			VD_CASE( BYTE_3_NORM, VK_FORMAT_R8G8B8_SNORM );
+			VD_CASE( BYTE_4_NORM, VK_FORMAT_R8G8B8A8_SNORM );
+
+			VD_CASE( UBYTE_1_NORM, VK_FORMAT_R8_UNORM );
+			VD_CASE( UBYTE_2_NORM, VK_FORMAT_R8G8_UNORM );
+			VD_CASE( UBYTE_3_NORM, VK_FORMAT_R8G8B8_UNORM );
+			VD_CASE( UBYTE_4_NORM, VK_FORMAT_R8G8B8A8_UNORM );
+
+			VD_CASE( SHORT_1, VK_FORMAT_R16_SINT );
+			VD_CASE( SHORT_2, VK_FORMAT_R16G16_SINT );
+			VD_CASE( SHORT_3, VK_FORMAT_R16G16B16_SINT );
+			VD_CASE( SHORT_4, VK_FORMAT_R16G16B16A16_SINT );
+
+			VD_CASE( USHORT_1, VK_FORMAT_R16_UINT );
+			VD_CASE( USHORT_2, VK_FORMAT_R16G16_UINT );
+			VD_CASE( USHORT_3, VK_FORMAT_R16G16B16_UINT );
+			VD_CASE( USHORT_4, VK_FORMAT_R16G16B16A16_UINT );
+
+			VD_CASE( SHORT_1_NORM, VK_FORMAT_R16_SNORM );
+			VD_CASE( SHORT_2_NORM, VK_FORMAT_R16G16_SNORM );
+			VD_CASE( SHORT_3_NORM, VK_FORMAT_R16G16B16_SNORM );
+			VD_CASE( SHORT_4_NORM, VK_FORMAT_R16G16B16A16_SNORM );
+
+			VD_CASE( USHORT_1_NORM, VK_FORMAT_R16_UNORM );
+			VD_CASE( USHORT_2_NORM, VK_FORMAT_R16G16_UNORM );
+			VD_CASE( USHORT_3_NORM, VK_FORMAT_R16G16B16_UNORM );
+			VD_CASE( USHORT_4_NORM, VK_FORMAT_R16G16B16A16_UNORM );
+
+			VD_CASE( INT32_1, VK_FORMAT_R32_SINT );
+			VD_CASE( INT32_2, VK_FORMAT_R32G32_SINT );
+			VD_CASE( INT32_3, VK_FORMAT_R32G32B32_SINT );
+			VD_CASE( INT32_4, VK_FORMAT_R32G32B32A32_SINT );
+
+			VD_CASE( UINT32_1, VK_FORMAT_R32_UINT );
+			VD_CASE( UINT32_2, VK_FORMAT_R32G32_UINT );
+			VD_CASE( UINT32_3, VK_FORMAT_R32G32B32_UINT );
+			VD_CASE( UINT32_4, VK_FORMAT_R32G32B32A32_UINT );
+
+			VD_CASE( FLOAT16_1, VK_FORMAT_R16_SFLOAT );
+			VD_CASE( FLOAT16_2, VK_FORMAT_R16G16_SFLOAT );
+			VD_CASE( FLOAT16_3, VK_FORMAT_R16G16B16_SFLOAT );
+			VD_CASE( FLOAT16_4, VK_FORMAT_R16G16B16A16_SFLOAT );
+
+			VD_CASE( FLOAT32_1, VK_FORMAT_R32_SFLOAT );
+			VD_CASE( FLOAT32_2, VK_FORMAT_R32G32_SFLOAT );
+			VD_CASE( FLOAT32_3, VK_FORMAT_R32G32B32_SFLOAT );
+			VD_CASE( FLOAT32_4, VK_FORMAT_R32G32B32A32_SFLOAT );
+		}
+
+		return VK_FORMAT_UNDEFINED;
+	}
+}
+
+namespace TrinityALImpl
+{
+	Tr2VertexLayoutAL::Tr2VertexLayoutAL()
+		:m_isValid( false )
+	{
+
+	}
+
+	ALResult Tr2VertexLayoutAL::Create( const Tr2VertexDefinition& definition, Tr2PrimaryRenderContextAL& )
+	{
+		Destroy();
+
+		for( auto it = begin( definition.m_items ); it != end( definition.m_items ); ++it )
+		{
+			VkVertexInputAttributeDescription desc;
+			desc.binding = it->m_stream;
+			desc.format = GetFormat( it->m_dataType );
+			desc.offset = it->m_offset;
+			m_attributes.push_back( desc );
+			m_streamRates[it->m_stream] = it->m_instanceStepRate ? VK_VERTEX_INPUT_RATE_INSTANCE : VK_VERTEX_INPUT_RATE_VERTEX;
+			m_streamCount = std::max( m_streamCount, it->m_stream + 1 );
+		}
+		m_definition = definition;
+		m_isValid = true;
+		return S_OK;
+	}
+
+	bool Tr2VertexLayoutAL::IsValid() const
+	{
+		return m_isValid;
+	}
+
+	void Tr2VertexLayoutAL::Destroy()
+	{
+		m_streamCount = 0;
+		m_isValid = false;
+		m_definition = Tr2VertexDefinition();
+		m_attributes.clear();
+	}
+
+	Tr2ALMemoryType Tr2VertexLayoutAL::GetMemoryClass() const
+	{
+		return AL_MEMORY_MANAGED;
+	}
+
+	void Tr2VertexLayoutAL::PopulateInputLayoutVulkan( std::vector<VkVertexInputAttributeDescription>& layout, const std::vector<Tr2ShaderPipelineInputAL>& shaderInputs ) const
+	{
+		layout.reserve( shaderInputs.size() );
+		for( auto it = begin( shaderInputs ); it != end( shaderInputs ); ++it )
+		{
+			auto& in = *it;
+			bool found = false;
+			for( size_t i = 0; i < m_attributes.size(); ++i )
+			{
+				auto& item = m_definition.m_items[i];
+				if( in.usage == item.m_usage && in.usageIndex == item.m_usageIndex )
+				{
+					auto attr = m_attributes[i];
+					attr.location = in.registerIndex;
+					layout.push_back( attr );
+					found = true;
+					break;
+				}
+			}
+			if( !found )
+			{
+				VkVertexInputAttributeDescription attr = { in.registerIndex, 0, VK_FORMAT_R32G32B32A32_SFLOAT, 0 };
+				layout.push_back( attr );
+			}
+		}
+	}
+
+	void Tr2VertexLayoutAL::Describe( Tr2DeviceResourceDescriptionAL& description ) const
+	{
+		description["type"] = "Tr2VertexLayoutAL";
+	}
+
+	ALResult Tr2VertexLayoutAL::SetName( const char* )
+	{
+		return E_NOTIMPL;
+	}
+}
+#endif

--- a/trinityal/vulkan/Tr2VertexLayoutALVulkan.h
+++ b/trinityal/vulkan/Tr2VertexLayoutALVulkan.h
@@ -1,0 +1,44 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   February 2019
+//    Copyright: CCP 2019
+//
+
+#pragma once
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "../include/Tr2VertexLayoutAL.h"
+#include "../Tr2VertexDefinition.h"
+#include "../include/Tr2ShaderAL.h"
+
+
+namespace TrinityALImpl
+{
+	class Tr2VertexLayoutAL : public Tr2DeviceResourceAL<Tr2VertexLayoutAL>
+	{
+	public:
+		Tr2VertexLayoutAL();
+
+		ALResult Create( const Tr2VertexDefinition& definition, Tr2PrimaryRenderContextAL& renderContext );
+		bool IsValid() const;
+		void Destroy();
+
+		Tr2ALMemoryType GetMemoryClass() const;
+
+		void PopulateInputLayoutVulkan( std::vector<VkVertexInputAttributeDescription>& layout, const std::vector<Tr2ShaderPipelineInputAL>& shaderInputs ) const;
+		void Describe( Tr2DeviceResourceDescriptionAL& description ) const;
+		ALResult SetName( const char* name );
+
+	private:
+		Tr2VertexDefinition m_definition;
+		std::vector<VkVertexInputAttributeDescription> m_attributes;
+		VkVertexInputRate m_streamRates[4];
+		uint32_t m_streamCount;
+		bool m_isValid;
+
+		friend class Tr2RenderContextAL;
+	};
+}
+
+#endif

--- a/trinityal/vulkan/Tr2VideoAdapterInfoALVulkan.cpp
+++ b/trinityal/vulkan/Tr2VideoAdapterInfoALVulkan.cpp
@@ -1,0 +1,697 @@
+#include "StdAfx.h"
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "Tr2VideoAdapterInfoALVulkan.h"
+#include "Tr2AdapterStructures.h"
+#include "VkResult.h"
+#include "ALLog.h"
+#include "UtilitiesVulkan.h"
+
+#include <dxgi.h>
+
+extern bool g_requestDeviceDebugLayer;
+
+namespace
+{
+	static const char* s_requiredInstanceExtensions[] = {
+		VK_KHR_SURFACE_EXTENSION_NAME,
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+		VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
+#elif defined(VK_USE_PLATFORM_XCB_KHR)
+		VK_KHR_XCB_SURFACE_EXTENSION_NAME,
+#elif defined(VK_USE_PLATFORM_XLIB_KHR)
+		VK_KHR_XLIB_SURFACE_EXTENSION_NAME,
+#endif
+		VK_EXT_DEBUG_REPORT_EXTENSION_NAME,
+	};
+	static const char* s_requiredDeviceExtensions[] = {
+		VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+	};
+
+	VkInstance s_instance = nullptr;
+
+	template <size_t Size>
+	const char* CheckExtensions( const std::vector<VkExtensionProperties>& available, const char* ( &required )[Size] )
+	{
+		for( auto name = std::begin( required ); name != std::end( required ); ++name )
+		{
+			bool found = false;
+			for( auto ext = begin( available ); ext != end( available ); ++ext )
+			{
+				if( strcmp( *name, ext->extensionName ) == 0 )
+				{
+					found = true;
+					break;
+				}
+			}
+			if( !found )
+			{
+				return *name;
+			}
+		}
+		return nullptr;
+	}
+
+	const char* s_validationLayers[] = {
+		"VK_LAYER_KHRONOS_validation",
+		"VK_LAYER_LUNARG_core_validation",
+		"VK_LAYER_LUNARG_standard_validation",
+		"VK_LAYER_LUNARG_parameter_validation",
+	};
+
+	void GetValidationLayers( std::vector<const char*>& validationLayers )
+	{
+		validationLayers.clear();
+
+		if( !g_requestDeviceDebugLayer )
+		{
+			return;
+		}
+
+		uint32_t layerCount;
+		vkEnumerateInstanceLayerProperties( &layerCount, nullptr );
+
+		std::vector<VkLayerProperties> availableLayers( layerCount );
+		vkEnumerateInstanceLayerProperties( &layerCount, availableLayers.data() );
+
+		for( auto it = std::begin( s_validationLayers ); it != std::end( s_validationLayers ); ++it )
+		{
+			auto found = std::find_if( begin( availableLayers ), end( availableLayers ), [&]( const VkLayerProperties& prop ) { return strcmp( prop.layerName, *it ) == 0; } );
+			if( found != end( availableLayers ) )
+			{
+				validationLayers.push_back( *it );
+			}
+		}
+	}
+
+	VKAPI_ATTR VkBool32 VKAPI_CALL ReportVulkanMessage(
+		VkDebugReportFlagsEXT flags,
+		VkDebugReportObjectTypeEXT objectType,
+		uint64_t object,
+		size_t location,
+		int32_t messageCode,
+		const char* pLayerPrefix,
+		const char* pMessage,
+		void* pUserData )
+	{
+#ifdef _WIN32
+		OutputDebugString( pMessage );
+		OutputDebugString( "\n" );
+#endif
+		if( ( flags & VK_DEBUG_REPORT_ERROR_BIT_EXT ) != 0 )
+		{
+			CCP_AL_LOGERR( "Vulkan validation error: %s", pMessage );
+		}
+		return VK_FALSE;
+	}
+
+	ALResult PopulateDeviceInfo( std::vector<TrinityALImpl::VulkanDeviceInfo>& s_devices )
+	{
+		if( !s_instance )
+		{
+			std::vector<VkExtensionProperties> availableExtensions;
+			FORWARD_HR( TrinityALImpl::QueryArray( &vkEnumerateInstanceExtensionProperties, nullptr, availableExtensions ) );
+
+			if( auto failed = CheckExtensions( availableExtensions, s_requiredInstanceExtensions ) )
+			{
+				CCP_AL_LOGERR( "Vulkan required extension \"%s\" is not supported", failed );
+				return E_FAIL;
+			}
+
+			VkApplicationInfo applicationInfo = {
+				VK_STRUCTURE_TYPE_APPLICATION_INFO,
+				nullptr,
+				nullptr,
+				VK_MAKE_VERSION( 1, 0, 0 ),
+				"Trinity",
+				VK_MAKE_VERSION( 1, 0, 0 ),
+				VK_MAKE_VERSION( 1,0,0 )
+			};
+
+			std::vector<const char*> validationLayers;
+			GetValidationLayers( validationLayers );
+
+			VkInstanceCreateInfo instanceCreateInfo = {
+				VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+				nullptr,
+				0,
+				&applicationInfo,
+				uint32_t( validationLayers.size() ),
+				validationLayers.empty() ? nullptr : validationLayers.data(),
+				_countof( s_requiredInstanceExtensions ),
+				s_requiredInstanceExtensions
+			};
+
+
+			CR_RETURN_HR( Vk2Al( vkCreateInstance( &instanceCreateInfo, nullptr, &s_instance ) ) );
+
+			if( g_requestDeviceDebugLayer )
+			{
+				PFN_vkCreateDebugReportCallbackEXT vkCreateDebugReportCallbackEXT =
+					reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>( vkGetInstanceProcAddr( s_instance, "vkCreateDebugReportCallbackEXT" ) );
+
+				VkDebugReportCallbackCreateInfoEXT callbackCreateInfo = {
+					VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT,
+					nullptr,
+					VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
+					&ReportVulkanMessage,
+					nullptr
+				};
+
+				VkDebugReportCallbackEXT callback;
+				Vk2Al( vkCreateDebugReportCallbackEXT( s_instance, &callbackCreateInfo, nullptr, &callback ) );
+			}
+		}
+
+		std::vector<VkPhysicalDevice> physicalDevices;
+		FORWARD_HR( TrinityALImpl::QueryArrayNotEmpty( &vkEnumeratePhysicalDevices, s_instance, physicalDevices ) );
+
+		VkPhysicalDevice selected_physical_device = VK_NULL_HANDLE;
+		uint32_t selected_queue_family_index = UINT32_MAX;
+		for( uint32_t i = 0; i < uint32_t( physicalDevices.size() ); ++i )
+		{
+			TrinityALImpl::VulkanDeviceInfo info;
+			info.device = physicalDevices[i];
+
+			vkGetPhysicalDeviceProperties( physicalDevices[i], &info.properties );
+			vkGetPhysicalDeviceFeatures( physicalDevices[i], &info.features );
+
+			uint32_t version = VK_VERSION_MAJOR( info.properties.apiVersion );
+
+			if( version < 1 || info.properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU )
+			{
+				continue;
+			}
+
+			std::vector<VkQueueFamilyProperties> queue_family_properties;
+			TrinityALImpl::QueryArrayNoFail( &vkGetPhysicalDeviceQueueFamilyProperties, physicalDevices[i], queue_family_properties );
+			if( queue_family_properties.empty() )
+			{
+				continue;
+			}
+
+			bool foundGraphicsQueue = false;
+			for( uint32_t j = 0; j < uint32_t( queue_family_properties.size() ); ++j )
+			{
+				if( ( queue_family_properties[j].queueCount > 0 ) && ( queue_family_properties[j].queueFlags & VK_QUEUE_GRAPHICS_BIT ) ) 
+				{
+					info.graphicsQueue = j;
+					foundGraphicsQueue = true;
+					break;
+				}
+			}
+			if( !foundGraphicsQueue )
+			{
+				continue;
+			}
+
+			std::vector<VkExtensionProperties> availableExtensions;
+			if( FAILED( TrinityALImpl::QueryArray( &vkEnumerateDeviceExtensionProperties, physicalDevices[i], nullptr, availableExtensions ) ) )
+			{
+				continue;
+			}
+
+			if( CheckExtensions( availableExtensions, s_requiredDeviceExtensions ) )
+			{
+				continue;
+			}
+
+
+			s_devices.push_back( info );
+		}
+		return S_OK;
+	}
+}
+
+
+
+using namespace Tr2RenderContextEnum;
+
+namespace
+{
+
+	//TODO does this survive a driver crash?
+
+	CComPtr<IDXGIFactory1> s_factory;
+
+
+	struct AdapterInfo
+	{
+		CComPtr<IDXGIAdapter1> m_adapter;
+		CComPtr<IDXGIOutput> m_output;
+
+		DXGI_OUTPUT_DESC m_outputDesc;
+		DXGI_ADAPTER_DESC1 m_desc;
+
+		std::map<DXGI_FORMAT, std::vector<DXGI_MODE_DESC>> m_displayModes;
+
+		size_t m_deviceInfoIndex;
+	};
+
+	struct DeviceInfo
+	{
+		static const unsigned FORMAT_COUNT = 100;
+		static const unsigned MAX_SAMPLE_COUNT = 8;
+
+		TrinityALImpl::VulkanDeviceInfo vulkanDevice;
+
+		uint32_t m_formatSupport[FORMAT_COUNT];
+		uint8_t m_qualityLevels[FORMAT_COUNT][MAX_SAMPLE_COUNT];
+	};
+
+	std::vector<AdapterInfo> s_adapters;
+	std::vector<DeviceInfo> s_deviceInfo;
+
+	HRESULT GetFallbackMode( DXGI_MODE_DESC &desc )
+	{
+		DEVMODE devMode;
+		memset( &devMode, 0, sizeof( devMode ) );
+		devMode.dmSize = sizeof( devMode );
+		if( !EnumDisplaySettings( 0, ENUM_CURRENT_SETTINGS, &devMode ) )
+		{
+			return E_FAIL;
+		}
+
+		desc.Width = devMode.dmPelsWidth;
+		desc.Height = devMode.dmPelsHeight;
+		desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+		desc.RefreshRate.Numerator = 0;
+		desc.RefreshRate.Denominator = 1;
+		desc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;
+		desc.Scaling = DXGI_MODE_SCALING_UNSPECIFIED;
+		return S_OK;
+	}
+
+	ALResult PopulateDisplayModes( AdapterInfo& output, DXGI_FORMAT backBufferFormat )
+	{
+		auto inserted = output.m_displayModes.insert( std::make_pair( backBufferFormat, std::vector<DXGI_MODE_DESC>() ) );
+		auto& displayModes = inserted.first->second;
+		if( !inserted.second )
+		{
+			return S_OK;
+		}
+
+		uint32_t count = 0;
+		HRESULT hr = output.m_output->GetDisplayModeList(
+			backBufferFormat,
+			0,
+			&count,
+			nullptr );
+		if( hr == E_FAIL && backBufferFormat == DXGI_FORMAT_B8G8R8A8_UNORM && output.m_deviceInfoIndex == 0 )
+		{
+			CCP_LOGWARN( "Failed to get available display modes. Consider updating video driver." );
+			displayModes.resize( 1 );
+			return GetFallbackMode( displayModes[0] );
+		}
+		if( hr == DXGI_ERROR_NOT_CURRENTLY_AVAILABLE && backBufferFormat == DXGI_FORMAT_B8G8R8A8_UNORM )
+		{
+			CCP_LOGWARN( "Tr2VideoAdapterInfo: failed to enumerate display modes (running in remote desktop?)" );
+			count = 1;
+		}
+		else if( FAILED( hr ) || ( count == 0 ) )
+		{
+			return hr;
+		}
+
+		CCP_ASSERT( count > 0 );
+
+		displayModes.resize( count );
+		hr = output.m_output->GetDisplayModeList( static_cast<DXGI_FORMAT>( backBufferFormat ),
+			0,
+			&count,
+			&displayModes[0] );
+		if( hr == DXGI_ERROR_NOT_CURRENTLY_AVAILABLE && backBufferFormat == DXGI_FORMAT_B8G8R8A8_UNORM && !displayModes.empty() )
+		{
+			return GetFallbackMode( displayModes[0] );
+		}
+		else if( FAILED( hr ) )
+		{
+			return hr;
+		}
+		return S_OK;
+	}
+
+	ALResult InitializeDirect3D()
+	{
+		s_adapters.resize( 0 );
+		s_deviceInfo.resize( 0 );
+
+		s_factory = nullptr;
+
+		std::vector<TrinityALImpl::VulkanDeviceInfo> vulkanDevices;
+		FORWARD_HR( PopulateDeviceInfo( vulkanDevices ) );
+
+
+		HANDLE heapsBefore[256];
+		uint32_t countBefore = ::GetProcessHeaps( 256, heapsBefore );
+		( countBefore );
+
+		CR_RETURN_HR( CreateDXGIFactory1(
+			__uuidof( IDXGIFactory1 ),
+			(void**)( &s_factory ) ) );
+
+		uint32_t dwFlags = 0;
+
+		if( !s_factory )
+		{
+			return E_FAIL;
+		}
+
+		CComPtr<IDXGIAdapter1> adapterPtr;
+
+		uint32_t adapterIndex = 0;
+		while( SUCCEEDED( s_factory->EnumAdapters1( adapterIndex++, &adapterPtr ) ) )
+		{
+
+			DXGI_ADAPTER_DESC1 adapterDesc;
+			CR_RETURN_HR( adapterPtr->GetDesc1( &adapterDesc ) );
+
+			//static_assert( sizeof( adapterDesc.AdapterLuid ) == VK_UUID_SIZE, "fuck" );
+
+			CCP_LOG( "Found video adapter \"%S\"", adapterDesc.Description );
+
+			DeviceInfo deviceInfo;
+			memset( deviceInfo.m_formatSupport, 0, sizeof( deviceInfo.m_formatSupport ) );
+			memset( deviceInfo.m_qualityLevels, 0, sizeof( deviceInfo.m_qualityLevels ) );
+			deviceInfo.vulkanDevice.device = nullptr;
+
+			for( uint32_t i = 0; i < uint32_t( vulkanDevices.size() ); ++i )
+			{
+				auto& vulkanDevice = vulkanDevices[i].properties;
+				if( vulkanDevice.vendorID == adapterDesc.VendorId && vulkanDevice.deviceID == adapterDesc.DeviceId )
+				{
+					deviceInfo.vulkanDevice = vulkanDevices[i];
+					break;
+				}
+			}
+
+			if( !deviceInfo.vulkanDevice.device )
+			{
+				continue;
+			}
+
+			CComPtr<IDXGIOutput> outputPtr;
+			uint32_t outputIndex = 0;
+			bool hasValidOutputs = false;
+			while( SUCCEEDED( adapterPtr->EnumOutputs( outputIndex++, &outputPtr ) ) )
+			{
+				AdapterInfo adapter;
+				adapter.m_adapter = adapterPtr;
+				adapter.m_desc = adapterDesc;
+				adapter.m_output = outputPtr;
+				adapter.m_deviceInfoIndex = s_deviceInfo.size();
+
+				CR_RETURN_HR( outputPtr->GetDesc( &adapter.m_outputDesc ) );
+
+				CCP_LOG( "Found video adapter output \"%S\"", adapter.m_outputDesc.DeviceName );
+
+				CR_RETURN_HR( PopulateDisplayModes( adapter, DXGI_FORMAT_B8G8R8A8_UNORM ) );
+				if( !adapter.m_displayModes[DXGI_FORMAT_B8G8R8A8_UNORM].empty() )
+				{
+					hasValidOutputs = true;
+					s_adapters.push_back( adapter );
+				}
+				outputPtr.Release();
+			}
+			if( hasValidOutputs )
+			{
+				s_deviceInfo.push_back( deviceInfo );
+			}
+
+			adapterPtr.Release();
+		}
+
+		return S_OK;
+	}
+
+}
+
+#define	CHECK_INIT	\
+	if( !s_factory )							\
+	{											\
+		CR_RETURN_HR( InitializeDirect3D() );	\
+	}
+
+#define CHECK_VALID_ADAPTER	\
+	if( adapterIndex >= s_adapters.size() )		\
+	{											\
+		return E_INVALIDARG;					\
+	}
+
+#define	CHECK_INIT_BOOL	\
+	if( !s_factory && !SUCCEEDED( InitializeDirect3D() ) )	\
+	{														\
+		return false;										\
+	}
+
+#define CHECK_VALID_ADAPTER_BOOL	\
+	if( adapterIndex >= s_adapters.size() )		\
+	{											\
+		return false;							\
+	}
+
+ALResult Tr2VideoAdapterInfo::GetAdapterCount( uint32_t& count )
+{
+	CHECK_INIT;
+
+	count = static_cast<uint32_t>( s_adapters.size() );
+	return S_OK;
+}
+
+ALResult Tr2VideoAdapterInfo::GetAdapterInfo( unsigned adapterIndex,
+	Tr2AdapterInfo& info )
+{
+	CHECK_INIT;
+	CHECK_VALID_ADAPTER;
+
+	auto & desc = s_adapters[adapterIndex].m_desc;
+	auto & outp = s_adapters[adapterIndex].m_outputDesc;
+
+	info.driver = "";
+	info.description = desc.Description;
+	info.deviceName = CW2A( outp.DeviceName );
+	info.driverVersion = 0;
+	info.vendorID = desc.VendorId;
+	info.deviceID = desc.DeviceId;
+	info.subSystemID = desc.SubSysId;
+	info.revision = desc.Revision;
+	memset( &info.deviceIdentifier, 0, sizeof( info.deviceIdentifier ) );
+
+	return S_OK;
+}
+
+ALResult Tr2VideoAdapterInfo::GetAdapterMonitor( unsigned adapterIndex,
+	void*& monitor )
+{
+	CHECK_INIT;
+	CHECK_VALID_ADAPTER;
+
+	monitor = s_adapters[adapterIndex].m_outputDesc.Monitor;
+	return S_OK;
+}
+
+ALResult Tr2VideoAdapterInfo::GetAdapterDisplayMode( unsigned adapterIndex,
+	Tr2DisplayModeInfo& mode )
+{
+	CHECK_INIT;
+	CHECK_VALID_ADAPTER;
+
+	auto & mm = s_adapters[adapterIndex].m_displayModes[DXGI_FORMAT_B8G8R8A8_UNORM][0];
+	mode.format = static_cast<PixelFormat>( mm.Format );
+	mode.refreshRateDenominator = mm.RefreshRate.Denominator;
+	mode.refreshRateNumerator = mm.RefreshRate.Numerator;
+	mode.scaling = static_cast<DisplayScaling>( mm.Scaling );
+	mode.scanlineOrdering = static_cast<ScanlineOrdering>( mm.ScanlineOrdering );
+#if 0
+	// the above is probably the same for everything, but the dimensions are just whatever happens
+	// to be in slot [0], so that's a guess.  TODO: format?
+	mode.height = mm.Height;
+	mode.width = mm.Width;
+#else
+	DEVMODE devMode;
+	memset( &devMode, 0, sizeof( devMode ) );
+	devMode.dmSize = sizeof( devMode );
+	if( !EnumDisplaySettings( 0, ENUM_CURRENT_SETTINGS, &devMode ) )
+	{
+		return E_FAIL;
+	}
+	mode.width = devMode.dmPelsWidth;
+	mode.height = devMode.dmPelsHeight;
+#endif
+
+	return S_OK;
+}
+
+ALResult Tr2VideoAdapterInfo::GetAdapterModeCount( unsigned adapterIndex,
+	Tr2RenderContextEnum::PixelFormat backBufferFormat,
+	unsigned& count )
+{
+	CHECK_INIT;
+	CHECK_VALID_ADAPTER;
+
+	count = 0;
+
+	auto & output = s_adapters[adapterIndex];
+	CR_RETURN_HR( PopulateDisplayModes( output, static_cast<DXGI_FORMAT>( backBufferFormat ) ) );
+
+	count = unsigned( output.m_displayModes[static_cast<DXGI_FORMAT>( backBufferFormat )].size() );
+	return S_OK;
+}
+
+ALResult Tr2VideoAdapterInfo::GetAdapterMode( unsigned adapterIndex,
+	Tr2RenderContextEnum::PixelFormat backBufferFormat,
+	unsigned modeIndex,
+	Tr2DisplayModeInfo& mode )
+{
+	CHECK_INIT;
+	CHECK_VALID_ADAPTER;
+
+	auto & output = s_adapters[adapterIndex];
+	CR_RETURN_HR( PopulateDisplayModes( output, static_cast<DXGI_FORMAT>( backBufferFormat ) ) );
+	auto& displayModes = output.m_displayModes[static_cast<DXGI_FORMAT>( backBufferFormat )];
+
+	if( modeIndex >= displayModes.size() )
+	{
+		return E_INVALIDARG;
+	}
+
+	auto & mm = displayModes[modeIndex];
+
+	mode.format = static_cast<PixelFormat>( mm.Format );
+	mode.height = mm.Height;
+	mode.refreshRateDenominator = mm.RefreshRate.Denominator;
+	mode.refreshRateNumerator = mm.RefreshRate.Numerator;
+	mode.scaling = static_cast<DisplayScaling>( mm.Scaling );
+	mode.scanlineOrdering = static_cast<ScanlineOrdering>( mm.ScanlineOrdering );
+	mode.width = mm.Width;
+	return S_OK;
+}
+
+ALResult Tr2VideoAdapterInfo::GetAdapterMaxTextureWidth( unsigned/*adapterIndex*/,
+	unsigned& maxWidth )
+{
+	maxWidth = 4096;
+	return S_OK;
+}
+
+bool Tr2VideoAdapterInfo::SupportsBackBufferFormat( unsigned adapterIndex,
+	Tr2RenderContextEnum::PixelFormat backBufferFormat )
+{
+	CHECK_INIT_BOOL;
+	CHECK_VALID_ADAPTER_BOOL;
+
+	if( backBufferFormat >= (unsigned)DeviceInfo::FORMAT_COUNT )
+	{
+		return false;
+	}
+
+	uint32_t flags = s_deviceInfo[s_adapters[adapterIndex].m_deviceInfoIndex].m_formatSupport[backBufferFormat];
+
+	// or should it be D3D11_FORMAT_SUPPORT_DISPLAY?
+	//if( ( flags & D3D11_FORMAT_SUPPORT_RENDER_TARGET ) == 0 )
+	//{
+	//	return false;
+	//}
+
+	return true;
+}
+
+bool Tr2VideoAdapterInfo::SupportsRenderTargetFormat( unsigned adapterIndex, Tr2RenderContextEnum::PixelFormat format )
+{
+	CHECK_INIT_BOOL;
+	CHECK_VALID_ADAPTER_BOOL;
+
+	if( format >= (unsigned)DeviceInfo::FORMAT_COUNT )
+	{
+		return false;
+	}
+
+	uint32_t flags = s_deviceInfo[s_adapters[adapterIndex].m_deviceInfoIndex].m_formatSupport[format];
+
+	//if( ( flags & D3D11_FORMAT_SUPPORT_RENDER_TARGET ) == 0 )
+	//{
+	//	return false;
+	//}
+
+	//if( withAutoGenMipmap && ( ( flags & D3D11_FORMAT_SUPPORT_MIP_AUTOGEN ) == 0 ) )
+	//{
+	//	return false;
+	//}
+
+	return true;
+}
+
+unsigned log2( unsigned int x )
+{
+	unsigned ans = 0;
+	while( x >>= 1 )
+	{
+		ans++;
+	}
+	return ans;
+}
+
+ALResult Tr2VideoAdapterInfo::GetAdapterMsaaSupport( unsigned adapterIndex,
+	Tr2RenderContextEnum::PixelFormat format,
+	unsigned msaaType,
+	unsigned& msaaQuality )
+{
+	CHECK_INIT;
+	CHECK_VALID_ADAPTER;
+
+	if( msaaType <= 1 )
+	{
+		msaaQuality = 0;
+		return S_OK;
+	}
+
+	if( format >= (unsigned)DeviceInfo::FORMAT_COUNT || msaaType >= (unsigned)DeviceInfo::MAX_SAMPLE_COUNT )
+	{
+		return E_INVALIDARG;
+	}
+
+	msaaQuality = s_deviceInfo[s_adapters[adapterIndex].m_deviceInfoIndex].m_qualityLevels[format][msaaType - 2];
+	return S_OK;
+}
+
+ALResult Tr2VideoAdapterInfo::RefreshData()
+{
+	return InitializeDirect3D();
+}
+
+bool Tr2VideoAdapterInfo::AreAdaptersDifferent( unsigned adapter1,
+	unsigned adapter2 )
+{
+	if( adapter1 == adapter2 )
+	{
+		return false;
+	}
+	if( adapter1 >= s_adapters.size() || adapter2 >= s_adapters.size() )
+	{
+		return true;
+	}
+
+	return s_adapters[adapter1].m_adapter != s_adapters[adapter2].m_adapter;
+}
+
+namespace TrinityALImpl
+{
+
+	ALResult GetVulkanInstance( VkInstance& instance )
+	{
+		CHECK_INIT;
+		instance = s_instance;
+		return S_OK;
+	}
+
+	ALResult GetPhysicalDevice( unsigned adapterIndex, VulkanDeviceInfo& device )
+	{
+		CHECK_INIT;
+		CHECK_VALID_ADAPTER;
+		device = s_deviceInfo[s_adapters[adapterIndex].m_deviceInfoIndex].vulkanDevice;
+		return S_OK;
+	}
+}
+
+#endif

--- a/trinityal/vulkan/Tr2VideoAdapterInfoALVulkan.h
+++ b/trinityal/vulkan/Tr2VideoAdapterInfoALVulkan.h
@@ -1,0 +1,63 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   February 2019
+//    Copyright: CCP 2019
+//
+
+#pragma once
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "../ALResult.h"
+#include "../Tr2RenderContextEnum.h"
+
+
+struct Tr2AdapterInfo;
+struct Tr2DisplayModeInfo;
+
+
+class Tr2VideoAdapterInfo
+{
+public:
+	static const unsigned DEFAULT_ADAPTER = 0;
+
+	static ALResult GetAdapterCount( unsigned& count );
+	static ALResult GetAdapterInfo( unsigned adapterIndex, Tr2AdapterInfo& info );
+
+	static ALResult GetAdapterMonitor( unsigned adapterIndex, void*& monitor );
+	static ALResult GetAdapterDisplayMode( unsigned adapterIndex, Tr2DisplayModeInfo& mode );
+	static ALResult GetAdapterModeCount( unsigned adapterIndex,
+		Tr2RenderContextEnum::PixelFormat backBufferFormat,
+		unsigned& count );
+	static ALResult GetAdapterMode( unsigned adapterIndex,
+		Tr2RenderContextEnum::PixelFormat backBufferFormat,
+		unsigned modeIndex,
+		Tr2DisplayModeInfo& mode );
+	static ALResult GetAdapterMsaaSupport( unsigned adapterIndex,
+		Tr2RenderContextEnum::PixelFormat format,
+		unsigned msaaType,
+		unsigned& msaaQuality );
+	static bool SupportsBackBufferFormat( unsigned adapterIndex,
+		Tr2RenderContextEnum::PixelFormat backBufferFormat );
+	static bool SupportsRenderTargetFormat( unsigned adapterIndex Tr2RenderContextEnum::PixelFormat format );
+	static ALResult GetAdapterMaxTextureWidth( unsigned adapterIndex, unsigned& maxWidth );
+	static bool AreAdaptersDifferent( unsigned adapter1, unsigned adapter2 );
+
+	static ALResult RefreshData();
+};
+
+namespace TrinityALImpl
+{
+	struct VulkanDeviceInfo
+	{
+		VkPhysicalDevice device;
+		VkPhysicalDeviceProperties properties;
+		VkPhysicalDeviceFeatures features;
+		uint32_t graphicsQueue;
+	};
+
+	ALResult GetPhysicalDevice( unsigned adapterIndex, VulkanDeviceInfo& device );
+	ALResult GetVulkanInstance( VkInstance& instance );
+}
+
+#endif

--- a/trinityal/vulkan/Tr2VideoAdapterInfoALVulkan.h
+++ b/trinityal/vulkan/Tr2VideoAdapterInfoALVulkan.h
@@ -39,7 +39,7 @@ public:
 		unsigned& msaaQuality );
 	static bool SupportsBackBufferFormat( unsigned adapterIndex,
 		Tr2RenderContextEnum::PixelFormat backBufferFormat );
-	static bool SupportsRenderTargetFormat( unsigned adapterIndex Tr2RenderContextEnum::PixelFormat format );
+	static bool SupportsRenderTargetFormat( unsigned adapterIndex, Tr2RenderContextEnum::PixelFormat format );
 	static ALResult GetAdapterMaxTextureWidth( unsigned adapterIndex, unsigned& maxWidth );
 	static bool AreAdaptersDifferent( unsigned adapter1, unsigned adapter2 );
 

--- a/trinityal/vulkan/UtilitiesVulkan.cpp
+++ b/trinityal/vulkan/UtilitiesVulkan.cpp
@@ -1,0 +1,220 @@
+////////////////////////////////////////////////////////////
+//
+//    Created:   May 2019
+//    Copyright: CCP 2019
+//
+
+#include "StdAfx.h"
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+#include "UtilitiesVulkan.h"
+#include "ALResult.h"
+#include "Tr2PrimaryRenderContextVulkan.h"
+
+namespace TrinityALImpl
+{
+	VkFormat GetVulkanFormat( Tr2RenderContextEnum::PixelFormat format )
+	{
+		switch( format )
+		{
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32G32B32A32_TYPELESS: return VK_FORMAT_R32G32B32A32_SFLOAT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32G32B32A32_FLOAT: return VK_FORMAT_R32G32B32A32_SFLOAT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32G32B32A32_UINT: return VK_FORMAT_R32G32B32A32_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32G32B32A32_SINT: return VK_FORMAT_R32G32B32A32_SINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32G32B32_TYPELESS: return VK_FORMAT_R32G32B32_SFLOAT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32G32B32_FLOAT: return VK_FORMAT_R32G32B32_SFLOAT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32G32B32_UINT: return VK_FORMAT_R32G32B32_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32G32B32_SINT: return VK_FORMAT_R32G32B32_SINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16G16B16A16_TYPELESS: return VK_FORMAT_R16G16B16A16_SFLOAT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16G16B16A16_FLOAT: return VK_FORMAT_R16G16B16A16_SFLOAT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16G16B16A16_UNORM: return VK_FORMAT_R16G16B16A16_UNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16G16B16A16_UINT: return VK_FORMAT_R16G16B16A16_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16G16B16A16_SNORM: return VK_FORMAT_R16G16B16A16_SNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16G16B16A16_SINT: return VK_FORMAT_R16G16B16A16_SINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32G32_TYPELESS: return VK_FORMAT_R32G32_SFLOAT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32G32_FLOAT: return VK_FORMAT_R32G32_SFLOAT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32G32_UINT: return VK_FORMAT_R32G32_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32G32_SINT: return VK_FORMAT_R32G32_SINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32G8X24_TYPELESS: return VK_FORMAT_D32_SFLOAT_S8_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_D32_FLOAT_S8X24_UINT: return VK_FORMAT_D32_SFLOAT_S8_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32_FLOAT_X8X24_TYPELESS: return VK_FORMAT_D32_SFLOAT_S8_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_X32_TYPELESS_G8X24_UINT: return VK_FORMAT_D32_SFLOAT_S8_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R10G10B10A2_TYPELESS: return VK_FORMAT_A2B10G10R10_UNORM_PACK32;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R10G10B10A2_UNORM: return VK_FORMAT_A2B10G10R10_UNORM_PACK32;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R10G10B10A2_UINT: return VK_FORMAT_A2B10G10R10_UINT_PACK32;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R11G11B10_FLOAT: return VK_FORMAT_B10G11R11_UFLOAT_PACK32;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8G8B8A8_TYPELESS: return VK_FORMAT_R8G8B8A8_UNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8G8B8A8_UNORM: return VK_FORMAT_R8G8B8A8_UNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8G8B8A8_UNORM_SRGB: return VK_FORMAT_R8G8B8A8_SRGB;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8G8B8A8_UINT: return VK_FORMAT_R8G8B8A8_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8G8B8A8_SNORM: return VK_FORMAT_R8G8B8A8_SNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8G8B8A8_SINT: return VK_FORMAT_R8G8B8A8_SINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16G16_TYPELESS: return VK_FORMAT_R16G16_SFLOAT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16G16_FLOAT: return VK_FORMAT_R16G16_SFLOAT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16G16_UNORM: return VK_FORMAT_R16G16_UNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16G16_UINT: return VK_FORMAT_R16G16_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16G16_SNORM: return VK_FORMAT_R16G16_SNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16G16_SINT: return VK_FORMAT_R16G16_SINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32_TYPELESS: return VK_FORMAT_R32_SFLOAT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_D32_FLOAT: return VK_FORMAT_D32_SFLOAT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32_FLOAT: return VK_FORMAT_R32_SFLOAT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32_UINT: return VK_FORMAT_R32_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R32_SINT: return VK_FORMAT_R32_SINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R24G8_TYPELESS: return VK_FORMAT_D24_UNORM_S8_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_D24_UNORM_S8_UINT: return VK_FORMAT_D24_UNORM_S8_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R24_UNORM_X8_TYPELESS: return VK_FORMAT_D24_UNORM_S8_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_X24_TYPELESS_G8_UINT: return VK_FORMAT_D24_UNORM_S8_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8G8_TYPELESS: return VK_FORMAT_R8G8_UNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8G8_UNORM: return VK_FORMAT_R8G8_UNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8G8_UINT: return VK_FORMAT_R8G8_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8G8_SNORM: return VK_FORMAT_R8G8_SNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8G8_SINT: return VK_FORMAT_R8G8_SINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16_TYPELESS: return VK_FORMAT_R16_SFLOAT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16_FLOAT: return VK_FORMAT_R16_SFLOAT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_D16_UNORM: return VK_FORMAT_D16_UNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16_UNORM: return VK_FORMAT_R16_UNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16_UINT: return VK_FORMAT_R16_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16_SNORM: return VK_FORMAT_R16_SNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R16_SINT: return VK_FORMAT_R16_SINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8_TYPELESS: return VK_FORMAT_R8_UNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8_UNORM: return VK_FORMAT_R8_UNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8_UINT: return VK_FORMAT_R8_UINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8_SNORM: return VK_FORMAT_R8_SNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8_SINT: return VK_FORMAT_R8_SINT;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_A8_UNORM: return VK_FORMAT_UNDEFINED;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R1_UNORM: return VK_FORMAT_UNDEFINED;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R9G9B9E5_SHAREDEXP: return VK_FORMAT_E5B9G9R9_UFLOAT_PACK32;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R8G8_B8G8_UNORM: return VK_FORMAT_UNDEFINED;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_G8R8_G8B8_UNORM: return VK_FORMAT_UNDEFINED;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC1_TYPELESS: return VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC1_UNORM: return VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC1_UNORM_SRGB: return VK_FORMAT_BC1_RGBA_SRGB_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC2_TYPELESS: return VK_FORMAT_BC2_UNORM_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC2_UNORM: return VK_FORMAT_BC2_UNORM_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC2_UNORM_SRGB: return VK_FORMAT_BC2_SRGB_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC3_TYPELESS: return VK_FORMAT_BC3_UNORM_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC3_UNORM: return VK_FORMAT_BC3_UNORM_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC3_UNORM_SRGB: return VK_FORMAT_BC3_SRGB_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC4_TYPELESS: return VK_FORMAT_BC4_UNORM_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC4_UNORM: return VK_FORMAT_BC4_UNORM_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC4_SNORM: return VK_FORMAT_BC4_SNORM_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC5_TYPELESS: return VK_FORMAT_BC5_UNORM_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC5_UNORM: return VK_FORMAT_BC5_UNORM_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC5_SNORM: return VK_FORMAT_BC5_SNORM_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_B5G6R5_UNORM: return VK_FORMAT_B5G6R5_UNORM_PACK16;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_B5G5R5A1_UNORM: return VK_FORMAT_B5G5R5A1_UNORM_PACK16;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_B8G8R8A8_UNORM: return VK_FORMAT_B8G8R8A8_UNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_B8G8R8X8_UNORM: return VK_FORMAT_B8G8R8A8_UNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_R10G10B10_XR_BIAS_A2_UNORM: return VK_FORMAT_UNDEFINED;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_B8G8R8A8_TYPELESS: return VK_FORMAT_B8G8R8A8_UNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_B8G8R8A8_UNORM_SRGB: return VK_FORMAT_B8G8R8A8_SRGB;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_B8G8R8X8_TYPELESS: return VK_FORMAT_B8G8R8_UNORM;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_B8G8R8X8_UNORM_SRGB: return VK_FORMAT_B8G8R8A8_SRGB;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC6H_TYPELESS: return VK_FORMAT_BC6H_SFLOAT_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC6H_UF16: return VK_FORMAT_BC6H_UFLOAT_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC6H_SF16: return VK_FORMAT_BC6H_SFLOAT_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC7_TYPELESS: return VK_FORMAT_BC7_UNORM_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC7_UNORM: return VK_FORMAT_BC7_UNORM_BLOCK;
+		case Tr2RenderContextEnum::PIXEL_FORMAT_BC7_UNORM_SRGB: return VK_FORMAT_BC7_SRGB_BLOCK;
+		default:
+			return VK_FORMAT_UNDEFINED;
+		}
+	}
+
+	ALResult AllocateMemory( VkDeviceMemory& memory, const VkMemoryRequirements& memoryRequirements, VkMemoryPropertyFlagBits memoryProperty, Tr2PrimaryRenderContextAL& renderContext )
+	{
+		VkPhysicalDeviceMemoryProperties memoryProperties;
+		vkGetPhysicalDeviceMemoryProperties( renderContext.m_physicalDevice, &memoryProperties );
+
+		for( uint32_t i = 0; i < memoryProperties.memoryTypeCount; ++i )
+		{
+			if( ( memoryRequirements.memoryTypeBits & ( 1 << i ) ) && ( ( memoryProperties.memoryTypes[i].propertyFlags & memoryProperty ) == memoryProperty ) )
+			{
+
+				VkMemoryAllocateInfo memory_allocate_info = {
+					VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+					nullptr,
+					memoryRequirements.size,
+					i
+				};
+
+				if( vkAllocateMemory( renderContext.m_device, &memory_allocate_info, nullptr, &memory ) == VK_SUCCESS )
+				{
+					return S_OK;
+				}
+			}
+		}
+		return E_FAIL;
+	}
+
+	ALResult CreateBuffer( VkBuffer& buffer, VkDeviceMemory& memory, size_t size, VkBufferUsageFlags usage, VkMemoryPropertyFlagBits memoryProperty, Tr2PrimaryRenderContextAL& renderContext )
+	{
+		buffer = VK_NULL_HANDLE;
+		memory = VK_NULL_HANDLE;
+
+		VkBufferCreateInfo createInfo = {
+			VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+			nullptr,
+			0,
+			size,
+			usage,
+			VK_SHARING_MODE_EXCLUSIVE,
+			0,
+			nullptr
+		};
+
+		CR_RETURN_HR( Vk2Al( vkCreateBuffer( renderContext.m_device, &createInfo, nullptr, &buffer ) ) );
+
+		VkMemoryRequirements memoryRequirements;
+		vkGetBufferMemoryRequirements( renderContext.m_device, buffer, &memoryRequirements );
+
+		CR_RETURN_HR( AllocateMemory( memory, memoryRequirements, memoryProperty, renderContext ) );
+		return Vk2Al( vkBindBufferMemory( renderContext.m_device, buffer, memory, 0 ) );
+	}
+
+	ALResult CreateImage( VkImage& image, VkDeviceMemory& memory, const Tr2BitmapDimensions& desc, const Tr2MsaaDesc& msaa, VkImageUsageFlags usage, VkMemoryPropertyFlagBits memoryProperty, Tr2PrimaryRenderContextAL& renderContext )
+	{
+		image = VK_NULL_HANDLE;
+		memory = VK_NULL_HANDLE;
+
+		VkImageType imageType;
+		if( desc.GetType() == Tr2RenderContextEnum::TEX_TYPE_3D )
+		{
+			imageType = VK_IMAGE_TYPE_3D;
+		}
+		else
+		{
+			imageType = VK_IMAGE_TYPE_2D;
+		}
+
+		VkImageCreateInfo createInfo = {
+			VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+			nullptr,
+			0,
+			imageType,
+			GetVulkanFormat( desc.GetFormat() ),
+			{ desc.GetWidth(), desc.GetHeight(), desc.GetDepth() },
+			desc.GetTrueMipCount(),
+			desc.GetArraySize(),
+			VkSampleCountFlagBits( msaa.samples ),
+			VK_IMAGE_TILING_OPTIMAL,
+			usage,
+			VK_SHARING_MODE_EXCLUSIVE,
+			0,
+			nullptr,
+			VK_IMAGE_LAYOUT_UNDEFINED
+		};
+
+		CR_RETURN_HR( Vk2Al( vkCreateImage( renderContext.m_device, &createInfo, nullptr, &image ) ) );
+
+		VkMemoryRequirements memoryRequirements;
+		vkGetImageMemoryRequirements( renderContext.m_device, image, &memoryRequirements );
+
+		CR_RETURN_HR( AllocateMemory( memory, memoryRequirements, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, renderContext ) );
+		CR_RETURN_HR( vkBindImageMemory( renderContext.m_device, image, memory, 0 ) );
+		return S_OK;
+	}
+
+}
+#endif

--- a/trinityal/vulkan/UtilitiesVulkan.h
+++ b/trinityal/vulkan/UtilitiesVulkan.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "VkResult.h"
+#include "include/Tr2PixelFormat.h"
+
+class Tr2PrimaryRenderContextAL;
+struct Tr2BitmapDimensions;
+struct Tr2MsaaDesc;
+
+namespace TrinityALImpl
+{
+
+	template <typename Func, typename A1, typename Result>
+	ALResult QueryArray( Func func, A1 a1, std::vector<Result>& result )
+	{
+		result.clear();
+		uint32_t count = 0;
+		CR_RETURN_HR( Vk2Al( ( *func )( a1, &count, nullptr ) ) );
+		if( count )
+		{
+			result.resize( count );
+			CR_RETURN_HR( Vk2Al( ( *func )( a1, &count, &result[0] ) ) );
+		}
+		return S_OK;
+	}
+
+	template <typename Func, typename A1, typename A2, typename Result>
+	ALResult QueryArray( Func func, A1 a1, A2 a2, std::vector<Result>& result )
+	{
+		result.clear();
+		uint32_t count = 0;
+		CR_RETURN_HR( Vk2Al( ( *func )( a1, a2, &count, nullptr ) ) );
+		if( count )
+		{
+			result.resize( count );
+			CR_RETURN_HR( Vk2Al( ( *func )( a1, a2, &count, &result[0] ) ) );
+		}
+		return S_OK;
+	}
+
+	template <typename Func, typename A1, typename Result>
+	void QueryArrayNoFail( Func func, A1 a1, std::vector<Result>& result )
+	{
+		result.clear();
+		uint32_t count = 0;
+		( *func )( a1, &count, nullptr );
+		if( count )
+		{
+			result.resize( count );
+			( *func )( a1, &count, &result[0] );
+		}
+	}
+
+	template <typename Func, typename A1, typename Result>
+	ALResult QueryArrayNotEmpty( Func func, A1 a1, std::vector<Result>& result )
+	{
+		FORWARD_HR( QueryArray( func, a1, result ) );
+		if( result.empty() )
+		{
+			return E_FAIL;
+		}
+		return S_OK;
+	}
+
+	template <typename Func, typename A1, typename A2, typename Result>
+	ALResult QueryArrayNotEmpty( Func func, A1 a1, A2 a2, std::vector<Result>& result )
+	{
+		FORWARD_HR( QueryArray( func, a1, a2, result ) );
+		if( result.empty() )
+		{
+			return E_FAIL;
+		}
+		return S_OK;
+	}
+
+	VkFormat GetVulkanFormat( Tr2RenderContextEnum::PixelFormat format );
+
+	ALResult AllocateMemory( VkDeviceMemory& memory, const VkMemoryRequirements& memoryRequirements, VkMemoryPropertyFlagBits memoryProperty, Tr2PrimaryRenderContextAL& renderContext );
+	ALResult CreateBuffer( VkBuffer& buffer, VkDeviceMemory& memory, size_t size, VkBufferUsageFlags usage, VkMemoryPropertyFlagBits memoryProperty, Tr2PrimaryRenderContextAL& renderContext );
+	ALResult CreateImage( VkImage& image, VkDeviceMemory& memory, const Tr2BitmapDimensions& desc, const Tr2MsaaDesc& msaa, VkImageUsageFlags usage, VkMemoryPropertyFlagBits memoryProperty, Tr2PrimaryRenderContextAL& renderContext );
+
+}

--- a/trinityal/vulkan/UtilitiesVulkan.h
+++ b/trinityal/vulkan/UtilitiesVulkan.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "VkResult.h"
+#include "../Tr2RenderContextEnum.h"
 
 class Tr2PrimaryRenderContextAL;
 struct Tr2MsaaDesc;

--- a/trinityal/vulkan/UtilitiesVulkan.h
+++ b/trinityal/vulkan/UtilitiesVulkan.h
@@ -3,7 +3,6 @@
 #include "VkResult.h"
 
 class Tr2PrimaryRenderContextAL;
-struct Tr2BitmapDimensions;
 struct Tr2MsaaDesc;
 
 namespace TrinityALImpl

--- a/trinityal/vulkan/UtilitiesVulkan.h
+++ b/trinityal/vulkan/UtilitiesVulkan.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "VkResult.h"
-#include "include/Tr2PixelFormat.h"
 
 class Tr2PrimaryRenderContextAL;
 struct Tr2BitmapDimensions;

--- a/trinityal/vulkan/VkResult.h
+++ b/trinityal/vulkan/VkResult.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "ALResult.h"
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+
+inline ALResult Vk2Al( VkResult result )
+{
+	switch( result )
+	{
+	case VK_SUCCESS:
+		return S_OK;
+	default:
+		return E_FAIL;
+	}
+}
+
+#endif

--- a/trinityal/vulkan/upscaling/Tr2UpscalingALVulkan.cpp
+++ b/trinityal/vulkan/upscaling/Tr2UpscalingALVulkan.cpp
@@ -1,0 +1,18 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Created:		April 2024
+// Copyright:	CCP 2024
+//
+#include "StdAfx.h"
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+#include "Tr2UpscalingALVulkan.h"
+
+namespace TrinityALImpl
+{
+Tr2UpscalingTechniqueAL* CreateUpscalingTechnique( Tr2UpscalingAL::Technique technique, Tr2UpscalingAL::Setting setting, bool frameGeneration, uint32_t adapter )
+{
+	return nullptr;
+}
+}
+#endif

--- a/trinityal/vulkan/upscaling/Tr2UpscalingALVulkan.h
+++ b/trinityal/vulkan/upscaling/Tr2UpscalingALVulkan.h
@@ -1,0 +1,16 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Created:		April 2024
+// Copyright:	CCP 2024
+//
+#pragma once
+#include "include/upscaling/Tr2UpscalingAL.h"
+
+#if TRINITY_PLATFORM == TRINITY_VULKAN
+namespace TrinityALImpl
+{
+static const std::vector<Tr2UpscalingAL::Technique> AVAILABLE_UPSCALING_TECHNIQUES = {};
+Tr2UpscalingTechniqueAL* CreateUpscalingTechnique( Tr2UpscalingAL::Technique technique, Tr2UpscalingAL::Setting setting, bool frameGeneration, uint32_t adapter );
+
+}
+#endif

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "git@github.com:ccpshanghai/vcpkg-registry.git",
-      "baseline": "a17800451f47b87d9f21a34948a54b6dfdfcd577",
+      "baseline": "24e57aa9dde725d8482e26bfa3ad93ede86a3396",
       "packages": ["python3", 
                    "carbon-*", 
                    "tracy",

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,7 +9,7 @@
       "kind": "git",
       "repository": "git@github.com:ccpshanghai/vcpkg-registry.git",
       "reference": "mobile-exp",
-      "baseline": "89451e3d96055d0ef5013f0c7fb41420e51df7df",
+      "baseline": "294693148db6b4a1129823dc1a0b58dc04800384",
       "packages": [
         "python3",
         "carbon-*",

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,7 +9,7 @@
       "kind": "git",
       "repository": "git@github.com:ccpshanghai/vcpkg-registry.git",
       "reference": "mobile-exp",
-      "baseline": "294693148db6b4a1129823dc1a0b58dc04800384",
+      "baseline": "113b8194b38ebd2a8aafd68e6efda96911df6b0b",
       "packages": [
         "python3",
         "carbon-*",

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,7 +9,7 @@
       "kind": "git",
       "repository": "git@github.com:ccpshanghai/vcpkg-registry.git",
       "reference": "mobile-exp",
-      "baseline": "82ea5ed34556e7ea464dc915a4f024e55f2d4043",
+      "baseline": "89451e3d96055d0ef5013f0c7fb41420e51df7df",
       "packages": [
         "python3",
         "carbon-*",

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,7 +9,7 @@
       "kind": "git",
       "repository": "git@github.com:ccpshanghai/vcpkg-registry.git",
       "reference": "mobile-exp",
-      "baseline": "113b819af04d689a668bf46d3176870963c2608d",
+      "baseline": "a5a0edac33b6638b3f7b93f126359fff3e48fcf7",
       "packages": [
         "python3",
         "carbon-*",

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,7 +9,7 @@
       "kind": "git",
       "repository": "git@github.com:ccpshanghai/vcpkg-registry.git",
       "reference": "mobile-exp",
-      "baseline": "113b8194b38ebd2a8aafd68e6efda96911df6b0b",
+      "baseline": "113b819af04d689a668bf46d3176870963c2608d",
       "packages": [
         "python3",
         "carbon-*",

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,26 +9,28 @@
       "kind": "git",
       "repository": "git@github.com:ccpshanghai/vcpkg-registry.git",
       "reference": "mobile-exp",
-      "baseline": "24e57aa9dde725d8482e26bfa3ad93ede86a3396",
-      "packages": ["python3", 
-                   "carbon-*", 
-                   "tracy",
-                   "greenlet",
-                   "ccp-debug-info",
-                   "crashpad",
-                   "zlib",
-                   "re2c",
-                   "amd-fidelityfx",
-                   "amd-fidelityfx-cacao",
-                   "amd-fidelityfx-cas",
-                   "amd-fidelityfx-fsr",
-                   "fxc",
-                   "granny",
-                   "intel-xess",
-                   "nvidia-aftermath",
-                   "nvidia-streamline",
-                   "openvdb"
-          ]
+      "baseline": "82ea5ed34556e7ea464dc915a4f024e55f2d4043",
+      "packages": [
+        "python3",
+        "carbon-*",
+        "tracy",
+        "greenlet",
+        "ccp-debug-info",
+        "crashpad",
+        "zlib",
+        "re2c",
+        "amd-fidelityfx",
+        "amd-fidelityfx-cacao",
+        "amd-fidelityfx-cas",
+        "amd-fidelityfx-fsr",
+        "fxc",
+        "granny",
+        "intel-xess",
+        "nvidia-aftermath",
+        "nvidia-streamline",
+        "openvdb",
+        "protobuf"
+      ]
     }
   ]
 }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,6 +8,7 @@
     {
       "kind": "git",
       "repository": "git@github.com:ccpshanghai/vcpkg-registry.git",
+      "reference": "mobile-exp",
       "baseline": "24e57aa9dde725d8482e26bfa3ad93ede86a3396",
       "packages": ["python3", 
                    "carbon-*", 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,7 +9,7 @@
       "kind": "git",
       "repository": "git@github.com:ccpshanghai/vcpkg-registry.git",
       "reference": "mobile-exp",
-      "baseline": "113b819af04d689a668bf46d3176870963c2608d",
+      "baseline": "9341d42c06822551922f4917d7cb5ad7c725680e",
       "packages": [
         "python3",
         "carbon-*",

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "git@github.com:ccpshanghai/vcpkg-registry.git",
-      "baseline": "f503eea8c313ba8f61d97a5bb0f37e7ba69f749c",
+      "baseline": "a17800451f47b87d9f21a34948a54b6dfdfcd577",
       "packages": ["python3", 
                    "carbon-*", 
                    "tracy",

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -7,8 +7,8 @@
   "registries": [
     {
       "kind": "git",
-      "repository": "git@github.com:carbonengine/vcpkg-registry.git",
-      "baseline": "a83134805f3fa07da6a6add87c4b250d9778bfd1",
+      "repository": "git@github.com:ccpshanghai/vcpkg-registry.git",
+      "baseline": "f503eea8c313ba8f61d97a5bb0f37e7ba69f749c",
       "packages": ["python3", 
                    "carbon-*", 
                    "tracy",

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,7 +9,7 @@
       "kind": "git",
       "repository": "git@github.com:ccpshanghai/vcpkg-registry.git",
       "reference": "mobile-exp",
-      "baseline": "9341d42c06822551922f4917d7cb5ad7c725680e",
+      "baseline": "113b819af04d689a668bf46d3176870963c2608d",
       "packages": [
         "python3",
         "carbon-*",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -172,6 +172,16 @@
         }
       ]
     },
+    "vulkan": {
+      "description": "Create Vulkan targets",
+      "supports": "windows & x64",
+      "dependencies": [
+        {
+          "name": "directx-dxc",
+          "version>=": "2023-03-01#2"
+        }
+      ]
+    },
     "with-granny": {
       "description": "Include Granny support",
       "dependencies": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -218,8 +218,17 @@
       "version": "1.15#14"
     },
     {
+      "$comment": "vulkan-headers, vulkan-loader and vulkan-memory-allocator are a matched SDK set and must move together: the loader's generated VulkanLoaderConfig.cmake hard-references the Vulkan::Headers target of its own release, so pinning one and leaving the others on a bare version>= lets a baseline move break the configure in whichever direction the unpinned side drifts (observed once already, headers pinned / loader floating -- see docs/spikes/M4-phase2a-test-harness.md §4b).",
+      "name": "vulkan-headers",
+      "version": "1.4.304.1#1"
+    },
+    {
       "name": "vulkan-loader",
       "version": "1.4.304.1"
+    },
+    {
+      "name": "vulkan-memory-allocator",
+      "version": "3.3.0"
     }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -179,6 +179,10 @@
         {
           "name": "directx-dxc",
           "version>=": "2023-03-01#2"
+        },
+        {
+          "name": "vulkan-loader",
+          "version>=": "1.4.304.1"
         }
       ]
     },
@@ -212,6 +216,10 @@
     {
       "name": "libsquish",
       "version": "1.15#14"
+    },
+    {
+      "name": "vulkan-loader",
+      "version": "1.4.304.1"
     }
   ]
 }


### PR DESCRIPTION
## Summary

<!-- One or two sentences: what does this PR do, and why? -->

## AI assistance disclosure

<!-- Did AI tools generate or significantly assist any part of this PR (code,
tests, commit messages, this description)? If so, briefly say what and how.
Write "None" if not. Be honest: disclosure isn't held against you. What gets a
PR closed is unverified output you can't stand behind, not the use of AI. -->

## Type of change

<!-- Tick all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup (no behaviour change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Breaking change (public API or ABI)
- [ ] Other (describe below)

## Linked issue (optional)

<!-- e.g. "Closes #123" or "Refs #456". Leave blank if this PR stands on its own. -->

## What changed

<!-- Short bullets. Aim for the diff-summary you'd want as a reviewer. -->

-
-

## Testing

<!-- What did you run locally? Paste the command if it's useful. New tests added? -->

## Platforms tested

<!-- Tick what applies. Leave blank if not relevant (e.g. a Python-only or docs change). -->

- [ ] Windows
- [ ] macOS
- [ ] Not applicable

## Screenshots / captures

<!-- Only if your change has a visual effect. Drag & drop images here. -->

## Checklist

- [ ] I've read [CONTRIBUTING.md](https://github.com/carbonengine/.github/blob/main/CONTRIBUTING.md).
- [ ] My commits follow the commit-message style described there.
- [ ] I've added or updated tests where it made sense.
- [ ] I've updated docs / inline API comments for any behaviour change.
- [ ] My CLA / ICLA is signed (the bot will let you know if it isn't).

---

<!--
Heads-up: builds run on our internal CI, not GitHub Actions. On all repos a
maintainer triggers the build after an initial review. Results appear as commit status checks. If you don't see activity
within a few working days, comment on the PR (the maintainers are subscribed), or
@-mention the maintainers team shown in its reviewers.
-->
