### PR TITLE
Make the RAND_MAX to float conversions explicit

### DIFF
--- a/trinity/Curves/Tr2CurveEulerRotationExpression.cpp
+++ b/trinity/Curves/Tr2CurveEulerRotationExpression.cpp
@@ -48,7 +48,7 @@ float Random( float a, float b )
 	{
 		return ( ( b - a ) * 0.41f ) + a;
 	}
-	return ( ( b - a ) * ( (float)rand() / RAND_MAX ) ) + a;
+	return ( ( b - a ) * ( (float)rand() / float( RAND_MAX ) ) ) + a;
 }
 
 // --------------------------------------------------------------------------------
@@ -86,7 +86,7 @@ Tr2CurveEulerRotationExpression::Tr2CurveEulerRotationExpression( IRoot* lockobj
 	PARENTLOCK( m_inputs ),
 	m_currentValue( 0, 0, 0, 1 ),
 	m_timeScale( 1 ),
-	m_randomConstant( float( rand() ) / RAND_MAX )
+	m_randomConstant( float( rand() ) / float( RAND_MAX ) )
 {
 }
 
@@ -297,7 +297,7 @@ Quaternion* Tr2CurveEulerRotationExpression::GetValueDoubleDotAt( Quaternion* in
 // --------------------------------------------------------------------------------
 void Tr2CurveEulerRotationExpression::ResetRandomConstant()
 {
-	m_randomConstant = float( rand() ) / RAND_MAX;
+	m_randomConstant = float( rand() ) / float( RAND_MAX );
 }
 
 // --------------------------------------------------------------------------------

--- a/trinity/Curves/Tr2CurveScalarExpression.cpp
+++ b/trinity/Curves/Tr2CurveScalarExpression.cpp
@@ -52,7 +52,7 @@ float Random( float a, float b )
 	{
 		return ( ( b - a ) * 0.41f ) + a;
 	}
-	return ( ( b - a ) * ( (float)rand() / RAND_MAX ) ) + a;
+	return ( ( b - a ) * ( (float)rand() / float( RAND_MAX ) ) ) + a;
 }
 
 // --------------------------------------------------------------------------------
@@ -89,7 +89,7 @@ Tr2CurveScalarExpression::Tr2CurveScalarExpression( IRoot* lockobj ) :
 	PARENTLOCK( m_inputs ),
 	m_currentValue( 0 ),
 	m_timeScale( 1 ),
-	m_randomConstant( float( rand() ) / RAND_MAX )
+	m_randomConstant( float( rand() ) / float( RAND_MAX ) )
 {
 }
 
@@ -236,7 +236,7 @@ float Tr2CurveScalarExpression::GetRandomConstant() const
 // --------------------------------------------------------------------------------
 void Tr2CurveScalarExpression::ResetRandomConstant()
 {
-	m_randomConstant = float( rand() ) / RAND_MAX;
+	m_randomConstant = float( rand() ) / float( RAND_MAX );
 }
 
 // --------------------------------------------------------------------------------

--- a/trinity/Curves/Tr2CurveVector3Expression.cpp
+++ b/trinity/Curves/Tr2CurveVector3Expression.cpp
@@ -48,7 +48,7 @@ float Random( float a, float b )
 	{
 		return ( ( b - a ) * 0.41f ) + a;
 	}
-	return ( ( b - a ) * ( (float)rand() / RAND_MAX ) ) + a;
+	return ( ( b - a ) * ( (float)rand() / float( RAND_MAX ) ) ) + a;
 }
 
 // --------------------------------------------------------------------------------
@@ -85,7 +85,7 @@ Tr2CurveVector3Expression::Tr2CurveVector3Expression( IRoot* lockobj ) :
 	PARENTLOCK( m_inputs ),
 	m_currentValue( 0, 0, 0 ),
 	m_timeScale( 1 ),
-	m_randomConstant( float( rand() ) / RAND_MAX )
+	m_randomConstant( float( rand() ) / float( RAND_MAX ) )
 {
 }
 
@@ -349,7 +349,7 @@ Vector3d* Tr2CurveVector3Expression::InterpolatedPosition( Vector3d* out, Be::Ti
 // --------------------------------------------------------------------------------
 void Tr2CurveVector3Expression::ResetRandomConstant()
 {
-	m_randomConstant = float( rand() ) / RAND_MAX;
+	m_randomConstant = float( rand() ) / float( RAND_MAX );
 }
 
 // --------------------------------------------------------------------------------

--- a/trinity/Curves/Tr2ScalarExprKeyCurve.cpp
+++ b/trinity/Curves/Tr2ScalarExprKeyCurve.cpp
@@ -44,7 +44,7 @@ static float perlin_wrap_simple( float x )
 // --------------------------------------------------------------------------------------
 static float frandom( float a, float b )
 {
-	return ( ( b - a ) * ( (float)rand() / RAND_MAX ) ) + a;
+	return ( ( b - a ) * ( (float)rand() / float( RAND_MAX ) ) ) + a;
 }
 
 namespace

--- a/trinity/Eve/Renderable/Stretch/EveStretch2.cpp
+++ b/trinity/Eve/Renderable/Stretch/EveStretch2.cpp
@@ -89,7 +89,7 @@ EveStretch2::EveStretch2( IRoot* lockObj ) :
 	m_destinationTransform( IdentityMatrix() ),
 	m_vb( BlueSharedString( "EveStretch2VB" ), &GetEveStretch2Quads )
 {
-	m_effectData[0] = Vector4( 0, 0, 0, float( rand() ) / RAND_MAX );
+	m_effectData[0] = Vector4( 0, 0, 0, float( rand() ) / float( RAND_MAX ) );
 	m_effectData[0] = Vector4( 1, 0, 0, 0 );
 }
 
@@ -136,7 +136,7 @@ float EveStretch2::GetCurveDuration()
 
 void EveStretch2::StartFiring( float delay )
 {
-	m_effectData[0].w = float( rand() ) / RAND_MAX;
+	m_effectData[0].w = float( rand() ) / float( RAND_MAX );
 	if( m_start )
 	{
 		m_start->PlayFrom( -delay );

--- a/trinity/Eve/SpaceObject/Children/Behaviors/ProcessLifetime.cpp
+++ b/trinity/Eve/SpaceObject/Children/Behaviors/ProcessLifetime.cpp
@@ -214,7 +214,7 @@ std::vector<Vector3> ProcessLifetime::CalculateBehavior( std::vector<DroneAgent>
 
 float ProcessLifetime::GetRandomOffset( float cylWidth ) const
 {
-	return static_cast<float>( RAND_MAX / ( 2 * ( cylWidth * m_wanderAmount ) ) );
+	return static_cast<float>( float( RAND_MAX ) / ( 2 * ( cylWidth * m_wanderAmount ) ) );
 }
 
 bool ProcessLifetime::ProcessTunnel( DroneAgent& agent, SplineTunnel& tunnel, int& pointID, float boundingSphere )
@@ -402,7 +402,7 @@ void ProcessLifetime::FindASpawnPoint( DroneAgent& agent, ProcessLifetimeData* d
 				Vector3 point = ( *tunnel )->splinePoints[0].pos;
 				for( int i = 0; i < 3; i++ )
 				{
-					point[i] += -( *tunnel )->pointOfNoReturnSize + static_cast<float>( rand() ) / ( static_cast<float>( RAND_MAX / ( 2 * ( *tunnel )->pointOfNoReturnSize ) ) );
+					point[i] += -( *tunnel )->pointOfNoReturnSize + static_cast<float>( rand() ) / ( static_cast<float>( float( RAND_MAX ) / ( 2 * ( *tunnel )->pointOfNoReturnSize ) ) );
 				}
 				potentialPoints.push_back( point );
 				potentialRotations.push_back( ( *tunnel )->splinePoints[0].rot );

--- a/trinity/Eve/SpaceObject/Children/EveChildParticleSphere.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildParticleSphere.cpp
@@ -348,7 +348,7 @@ void EveChildParticleSphere::ApplyConstraint( const Vector3& previousReferencePo
 void EveChildParticleSphere::FillParticleData( float** particle, const Vector3& previousReferencePosition, const Vector3& velocityDirection )
 {
 	auto randf = []() {
-		return float( rand() ) / RAND_MAX;
+		return float( rand() ) / float( RAND_MAX );
 	};
 
 	if( m_positionElement.m_bufferType != Tr2ParticleElementData::COUNT )
@@ -410,7 +410,7 @@ void EveChildParticleSphere::AddParticles( const Vector3& previousReferencePosit
 	}
 
 	auto randf = []() {
-		return float( rand() ) / RAND_MAX;
+		return float( rand() ) / float( RAND_MAX );
 	};
 
 	float* particle[Tr2ParticleElementData::COUNT];

--- a/trinity/Eve/SpaceObject/Children/SmartLightSets/attributeModifiers/EveSmartLightAttributeModifierExpressionBucket.cpp
+++ b/trinity/Eve/SpaceObject/Children/SmartLightSets/attributeModifiers/EveSmartLightAttributeModifierExpressionBucket.cpp
@@ -39,7 +39,7 @@ float RandomHash( const EveSmartLightAttributeModifierExpressionBucket* bucket, 
 
 float Random( float a, float b )
 {
-	return ( ( b - a ) * ( (float)rand() / RAND_MAX ) ) + a;
+	return ( ( b - a ) * ( (float)rand() / float( RAND_MAX ) ) ) + a;
 }
 
 float Input( const EveSmartLightAttributeModifierExpressionBucket* bucket, float index )
@@ -84,7 +84,7 @@ CcpParser::Constant s_constants[] = {
 
 EveSmartLightAttributeModifierExpressionBucket::EveSmartLightAttributeModifierExpressionBucket( IRoot* lockobj ) :
 	PARENTLOCK( m_inputs ),
-	m_randomConstant( float( rand() ) / RAND_MAX )
+	m_randomConstant( float( rand() ) / float( RAND_MAX ) )
 {
 	m_name = "ExpressionBucket";
 	m_expression = "";

--- a/trinity/Eve/SpaceObject/Utils/EveDistributionMethods/DistributionSpawners/EveDistributionSpawnerTriggerSnake.cpp
+++ b/trinity/Eve/SpaceObject/Utils/EveDistributionMethods/DistributionSpawners/EveDistributionSpawnerTriggerSnake.cpp
@@ -66,7 +66,7 @@ void EveDistributionSpawnerTriggerSnake::UpdateSyncronous( const EveUpdateContex
 		m_currentTravelTime = 0.f;
 		m_travelProgress = 0.f;
 		m_numDestinationsReached++;
-		m_travelDurationToNextPoint = Lerp( m_minTimeBetweenTriggers, m_maxTimeBetweenTriggers, (float)rand() / RAND_MAX );
+		m_travelDurationToNextPoint = Lerp( m_minTimeBetweenTriggers, m_maxTimeBetweenTriggers, (float)rand() / float( RAND_MAX ) );
 
 		Vector3 searchPoint = Lerp( m_lastTarget, m_targetPoint, 1.3f ); // overshoot to reduce u-turns
 		int32_t closetsPlace = owner.GetClosestFreePlacement( searchPoint );

--- a/trinity/Eve/Volume/EveEllipsoidVolume.cpp
+++ b/trinity/Eve/Volume/EveEllipsoidVolume.cpp
@@ -123,18 +123,18 @@ void EveEllipsoidVolume::GeneratePointsInVolume( std::vector<Vector3>& points, s
 
 	for( size_t i = 0; i < howManyToAdd; i++ )
 	{
-		float a = TRI_2PI * ( float( rand() ) / RAND_MAX );
-		float z = ( float( rand() ) / RAND_MAX ) * 2.f - 1.f;
+		float a = TRI_2PI * ( float( rand() ) / float( RAND_MAX ) );
+		float z = ( float( rand() ) / float( RAND_MAX ) ) * 2.f - 1.f;
 		Vector3 angle( sqrt( 1.f - z * z ) * cos( a ), sqrt( 1.f - z * z ) * sin( a ), z );
 		angle = Normalize( angle );
 
-		if( ( float( rand() ) / RAND_MAX ) > sizeDifference )
+		if( ( float( rand() ) / float( RAND_MAX ) ) > sizeDifference )
 		{
-			position = angle * ( m_innerShape + ( m_shape - m_innerShape ) * pow( (float)rand() / RAND_MAX, 0.75f * fallOffFactor ) );
+			position = angle * ( m_innerShape + ( m_shape - m_innerShape ) * pow( (float)rand() / float( RAND_MAX ), 0.75f * fallOffFactor ) );
 		}
 		else
 		{
-			position = angle * ( m_innerShape * pow( (float)rand() / RAND_MAX, 1.f / 3.f ) );
+			position = angle * ( m_innerShape * pow( (float)rand() / float( RAND_MAX ), 1.f / 3.f ) );
 		}
 
 		points.push_back( position );

--- a/trinity/Eve/Volume/EveSphereVolume.cpp
+++ b/trinity/Eve/Volume/EveSphereVolume.cpp
@@ -61,10 +61,10 @@ void EveSphereVolume::GeneratePointsInVolume( std::vector<Vector3>& points, size
 	{
 		for( size_t i = 0; i < howManyToAdd; i++ )
 		{
-			float dist = m_innerSphere.radius + circleDiffRange * pow( (float)rand() / RAND_MAX, 1.f / 3.f );
+			float dist = m_innerSphere.radius + circleDiffRange * pow( (float)rand() / float( RAND_MAX ), 1.f / 3.f );
 
-			float a = TRI_2PI * ( float( rand() ) / RAND_MAX );
-			float z = ( float( rand() ) / RAND_MAX ) * 2.f - 1.f;
+			float a = TRI_2PI * ( float( rand() ) / float( RAND_MAX ) );
+			float z = ( float( rand() ) / float( RAND_MAX ) ) * 2.f - 1.f;
 			Vector3 angle( sqrt( 1.f - z * z ) * cos( a ), sqrt( 1.f - z * z ) * sin( a ), z );
 
 			position = angle * dist;
@@ -80,19 +80,19 @@ void EveSphereVolume::GeneratePointsInVolume( std::vector<Vector3>& points, size
 
 		for( size_t i = 0; i < howManyToAdd; i++ )
 		{
-			if( (float)rand() / RAND_MAX < sizeDifference )
+			if( (float)rand() / float( RAND_MAX ) < sizeDifference )
 			{
 				// inner volume
-				dist = m_innerSphere.radius * pow( (float)rand() / RAND_MAX, 1.f / 3.f );
+				dist = m_innerSphere.radius * pow( (float)rand() / float( RAND_MAX ), 1.f / 3.f );
 			}
 			else
 			{
 				// outer volume
-				dist = m_innerSphere.radius + circleDiffRange * pow( (float)rand() / RAND_MAX, fallOffFactor );
+				dist = m_innerSphere.radius + circleDiffRange * pow( (float)rand() / float( RAND_MAX ), fallOffFactor );
 			}
 
-			float a = TRI_2PI * ( float( rand() ) / RAND_MAX );
-			float z = ( float( rand() ) / RAND_MAX ) * 2.f - 1.f;
+			float a = TRI_2PI * ( float( rand() ) / float( RAND_MAX ) );
+			float z = ( float( rand() ) / float( RAND_MAX ) ) * 2.f - 1.f;
 			Vector3 angle( sqrt( 1.f - z * z ) * cos( a ), sqrt( 1.f - z * z ) * sin( a ), z );
 
 			position = angle * dist;


### PR DESCRIPTION
## Summary

`RAND_MAX` is `32767` on Windows and converts to `float` exactly, but it is
`INT_MAX` everywhere else, where `2147483647` has no exact `float`
representation. Clang raises `-Wimplicit-const-int-float-conversion` and the
build fails under `-Werror`, which is what currently stops `trinity`
compiling on anything but Windows. This makes the conversion explicit at all
32 sites.

## AI assistance disclosure

Substantial. Claude (via Claude Code) found the failures by building
`trinity_metal` on macOS, applied the edits, and wrote the commit message and
this description. Every changed line was reviewed and the 30 -> 1 error count
is from real builds, not an estimate. Not verified: no Windows build, and no
runtime testing (there is no behaviour change to test).

## Type of change

- [x] Bug fix
- [x] Refactor / cleanup (no behaviour change)
- [ ] New feature
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Breaking change (public API or ABI)
- [ ] Other (describe below)

Both apply: it fixes a build failure, and the emitted code is unchanged.

## Linked issue (optional)

None.

## What changed

- Made `RAND_MAX`'s conversion to `float` explicit at 32 sites across 11
  files, all the same idiom:
  `( (float)rand() / RAND_MAX )` -> `( (float)rand() / float( RAND_MAX ) )`
- Two sites in `ProcessLifetime.cpp` (lines 217 and 405) have `RAND_MAX` as
  the numerator rather than the divisor. They divide by a `float`, so it is
  the same conversion, fixed the same way.
- No logic touched. The conversion was already happening implicitly; it is
  now written out, which is what silences the diagnostic. Values are
  bit-identical on every platform, Windows included.

## Testing

```
cmake --build .cmake-build-arm64-osx-debug --target trinity_metal -j8 -- -k
```

`trinity_metal` on `arm64-osx-debug`: **30 errors before, 1 after**. The
remaining error is `variable 'mesh' set but not used` in
`EveChildMesh.cpp:886`, an unrelated diagnostic left alone here. With that
one also fixed locally, the target links cleanly.

No tests added: `trinity` has no test target or test sources, so there is
nothing to extend. Per CONTRIBUTING I would have run the component's tests
locally, but none exist for this component.

This is a compile-time diagnostic fix with no runtime behaviour change, so
there is nothing to exercise at runtime beyond the build itself.

## Platforms tested

- [ ] Windows
- [x] macOS
- [ ] Not applicable

**Not built on Windows.** That is the platform most likely to regress from a
careless edit here, so it is worth a maintainer confirming. The change should
be a no-op there: `RAND_MAX` is `32767`, the conversion was already implicit,
and making it explicit does not alter the value.

## Screenshots / captures

Not applicable.

## Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/carbonengine/.github/blob/main/CONTRIBUTING.md).
- [x] My commits follow the commit-message style described there.
- [ ] I've added or updated tests where it made sense.
- [ ] I've updated docs / inline API comments for any behaviour change.
- [ ] My CLA / ICLA is signed (the bot will let you know if it isn't).

On the unticked boxes: no tests were added because `trinity` has no test
infrastructure, and no docs were updated because there is no behaviour change
to document. Neither is being skipped silently. The CLA box is left for the
submitter to confirm.

Commit checked against the seven rules: 47-character subject, imperative
mood, no trailing period, body wrapped at 72.
