### PR TITLE
Plat 11963 modular instances dont move

### DIFF
--- a/trinity/Eve/EveInstancedMeshManager.cpp
+++ b/trinity/Eve/EveInstancedMeshManager.cpp
@@ -1046,3 +1046,16 @@ bool EveInstancedMeshManager::InstanceFlags::operator!=( const InstanceFlags& ot
 {
 	return m_flags != other.m_flags;
 }
+
+Matrix EveInstancedMeshManager::StaticPerInstanceData::ToMatrix() const
+{
+	return Transpose( Matrix(
+		worldTransform[0].x, worldTransform[0].y, worldTransform[0].z, worldTransform[0].w, worldTransform[1].x, worldTransform[1].y, worldTransform[1].z, worldTransform[1].w, worldTransform[2].x, worldTransform[2].y, worldTransform[2].z, worldTransform[2].w, 0.f, 0.f, 0.f, 1.f ) );
+}
+
+void EveInstancedMeshManager::StaticPerInstanceData::SetTransform( const Matrix& m )
+{
+	worldTransform[0] = Vector4( m._11, m._21, m._31, m._41 );
+	worldTransform[1] = Vector4( m._12, m._22, m._32, m._42 );
+	worldTransform[2] = Vector4( m._13, m._23, m._33, m._43 );
+}

--- a/trinity/Eve/EveInstancedMeshManager.cpp
+++ b/trinity/Eve/EveInstancedMeshManager.cpp
@@ -1046,16 +1046,3 @@ bool EveInstancedMeshManager::InstanceFlags::operator!=( const InstanceFlags& ot
 {
 	return m_flags != other.m_flags;
 }
-
-Matrix EveInstancedMeshManager::StaticPerInstanceData::ToMatrix() const
-{
-	return Transpose( Matrix(
-		worldTransform[0].x, worldTransform[0].y, worldTransform[0].z, worldTransform[0].w, worldTransform[1].x, worldTransform[1].y, worldTransform[1].z, worldTransform[1].w, worldTransform[2].x, worldTransform[2].y, worldTransform[2].z, worldTransform[2].w, 0.f, 0.f, 0.f, 1.f ) );
-}
-
-void EveInstancedMeshManager::StaticPerInstanceData::SetTransform( const Matrix& m )
-{
-	worldTransform[0] = Vector4( m._11, m._21, m._31, m._41 );
-	worldTransform[1] = Vector4( m._12, m._22, m._32, m._42 );
-	worldTransform[2] = Vector4( m._13, m._23, m._33, m._43 );
-}

--- a/trinity/Eve/EveInstancedMeshManager.h
+++ b/trinity/Eve/EveInstancedMeshManager.h
@@ -27,18 +27,15 @@ public:
 
 	struct DynamicPerInstanceData
 	{
-		Vector4 worldTransform[3];
-		Vector4 prevWorldTransform[3];
+		Float4x3 worldTransform;
+		Float4x3 prevWorldTransform;
 		uint32_t sphereIndex = 0;
 	};
 
 	struct StaticPerInstanceData
 	{
-		Vector4 worldTransform[3];
+		Float4x3 worldTransform;
 		uint32_t sphereIndex = 0;
-
-		Matrix ToMatrix() const;
-		void SetTransform( const Matrix& m );
 	};
 
 	template <typename T>
@@ -145,14 +142,14 @@ public:
 private:
 	struct StaticPerInstanceBufferElement
 	{
-		Vector4 worldTransform[3];
+		Float4x3 worldTransform;
 		uint32_t perObjectDataIndex = 0;
 	};
 
 	struct DynamicPerInstanceBufferElement
 	{
-		Vector4 worldTransform[3];
-		Vector4 prevWorldTransform[3];
+		Float4x3 worldTransform;
+		Float4x3 prevWorldTransform;
 		uint32_t perObjectDataIndex = 0;
 	};
 

--- a/trinity/Eve/EveInstancedMeshManager.h
+++ b/trinity/Eve/EveInstancedMeshManager.h
@@ -36,6 +36,9 @@ public:
 	{
 		Vector4 worldTransform[3];
 		uint32_t sphereIndex = 0;
+
+		Matrix ToMatrix() const;
+		void SetTransform( const Matrix& m );
 	};
 
 	template <typename T>

--- a/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.cpp
@@ -594,7 +594,7 @@ bool EveChildInstancedMeshes::SetInstanceTransformByPartTag( PartTag partTag, co
 	bool changed = false;
 	for( auto& mesh : m_meshes )
 	{
-		for( int i = 0; i < mesh.instances.size(); i++ )
+		for( size_t i = 0; i < mesh.instances.size(); ++i )
 		{
 			if( mesh.partTags[i] == partTag )
 			{

--- a/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.cpp
@@ -145,9 +145,8 @@ void EveChildInstancedMeshes::PushRtGeometry( Tr2RaytracingManager& rtManager ) 
 				}
 			}
 
-			XMMATRIX m = *reinterpret_cast<const Matrix*>( instanceTransform.worldTransform );
-			m.r[3] = XMVectorSet( 0, 0, 0, 1 );
-			m = XMMatrixMultiply( XMMatrixTranspose( m ), m_worldTransform );
+			XMMATRIX m = Matrix( instanceTransform.worldTransform );
+			m = XMMatrixMultiply( m, m_worldTransform );
 			mesh.rtMeshes[lodIndex].instanceWorldTransforms.push_back( Float4x3( Matrix( m ) ) );
 		}
 
@@ -275,10 +274,11 @@ void EveChildInstancedMeshes::UpdateAsyncronous( const EveUpdateContext& updateC
 
 		for( const auto& instance : mesh.instances )
 		{
-			Vector3 position = Vector3( instance.worldTransform[0].w, instance.worldTransform[1].w, instance.worldTransform[2].w );
-			float scale = std::sqrtf( std::max( { LengthSq( instance.worldTransform[0].GetXYZ() ),
-												  LengthSq( instance.worldTransform[1].GetXYZ() ),
-												  LengthSq( instance.worldTransform[2].GetXYZ() ) } ) );
+			Matrix m = instance.worldTransform;
+			Vector3 position = m.GetTranslation();
+			float scale = std::sqrtf( std::max( { LengthSq( Vector3( m._11, m._12, m._13 ) ),
+												  LengthSq( Vector3( m._21, m._22, m._23 ) ),
+												  LengthSq( Vector3( m._31, m._32, m._33 ) ) } ) );
 			position = TransformCoord( position, m_worldTransform );
 			scale *= worldScale;
 			mesh.instanceSpheres[&instance - mesh.instances.data()] = CcpMath::Sphere( position, radius * scale );
@@ -449,7 +449,7 @@ void EveChildInstancedMeshes::AddMesh(
 		for( size_t i = 0; i < count; ++i )
 		{
 			EveInstancedMeshManager::StaticPerInstanceData instanceData;
-			instanceData.SetTransform( instanceTransforms[i] );
+			instanceData.worldTransform = Float4x3( instanceTransforms[i] );
 			instanceData.sphereIndex = static_cast<uint32_t>( existingCount + i );
 			mesh.instances.push_back( instanceData );
 			mesh.partTags.push_back( partTag );
@@ -490,7 +490,7 @@ void EveChildInstancedMeshes::AddMesh(
 	for( size_t i = 0; i < count; ++i )
 	{
 		EveInstancedMeshManager::StaticPerInstanceData instanceData;
-		instanceData.SetTransform( instanceTransforms[i] );
+		instanceData.worldTransform = Float4x3( instanceTransforms[i] );
 		instanceData.sphereIndex = static_cast<uint32_t>( i );
 		mesh.instances.push_back( instanceData );
 		mesh.partTags.push_back( partTag );
@@ -591,13 +591,14 @@ void EveChildInstancedMeshes::RemoveInstancesByPartTag( EveSpaceObjectChild::Par
 void EveChildInstancedMeshes::SetInstanceTransformByPartTag( PartTag partTag, const Vector3& translation, const Quaternion& rotation, Vector3 scale )
 {
 	Matrix m = TransformationMatrix( scale, rotation, translation );
+	const Float4x3 packedTransform( m );
 	for( auto& mesh : m_meshes )
 	{
 		for( size_t i = 0; i < mesh.instances.size(); ++i )
 		{
 			if( mesh.partTags[i] == partTag )
 			{
-				mesh.instances[i].SetTransform( m );
+				mesh.instances[i].worldTransform = packedTransform;
 			}
 		}
 	}
@@ -792,7 +793,7 @@ BluePy EveChildInstancedMeshes::GetInstancesTransforms( uint32_t meshId ) const
 	{
 		Vector3 scale, translation;
 		Quaternion rotation;
-		Decompose( scale, rotation, translation, instance.ToMatrix() );
+		Decompose( scale, rotation, translation, instance.worldTransform );
 
 		PyObject* transform = PyTuple_New( 3 );
 		PyTuple_SetItem( transform, 0, ToPython( translation ) );
@@ -1074,7 +1075,7 @@ void EveChildInstancedMeshes::UpdateOverlayInstanceData( const EveSpaceObjectVSD
 			const auto& wt = mesh.instances[i].worldTransform;
 			OverlayInstancePod& pod = ( *mesh.overlayPods )[i];
 
-			Matrix local = mesh.instances[i].ToMatrix();
+			Matrix local = mesh.instances[i].worldTransform;
 
 			Matrix worldTransform = Transpose( local * m_worldTransform );
 			Matrix worldTransformLast = Transpose( local * prevWorldTransform );

--- a/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.cpp
@@ -449,10 +449,7 @@ void EveChildInstancedMeshes::AddMesh(
 		for( size_t i = 0; i < count; ++i )
 		{
 			EveInstancedMeshManager::StaticPerInstanceData instanceData;
-			auto& mat = instanceTransforms[i];
-			instanceData.worldTransform[0] = Vector4( mat._11, mat._21, mat._31, mat._41 );
-			instanceData.worldTransform[1] = Vector4( mat._12, mat._22, mat._32, mat._42 );
-			instanceData.worldTransform[2] = Vector4( mat._13, mat._23, mat._33, mat._43 );
+			instanceData.SetTransform( instanceTransforms[i] );
 			instanceData.sphereIndex = static_cast<uint32_t>( existingCount + i );
 			mesh.instances.push_back( instanceData );
 			mesh.partTags.push_back( partTag );
@@ -493,10 +490,7 @@ void EveChildInstancedMeshes::AddMesh(
 	for( size_t i = 0; i < count; ++i )
 	{
 		EveInstancedMeshManager::StaticPerInstanceData instanceData;
-		auto& mat = instanceTransforms[i];
-		instanceData.worldTransform[0] = Vector4( mat._11, mat._21, mat._31, mat._41 );
-		instanceData.worldTransform[1] = Vector4( mat._12, mat._22, mat._32, mat._42 );
-		instanceData.worldTransform[2] = Vector4( mat._13, mat._23, mat._33, mat._43 );
+		instanceData.SetTransform( instanceTransforms[i] );
 		instanceData.sphereIndex = static_cast<uint32_t>( i );
 		mesh.instances.push_back( instanceData );
 		mesh.partTags.push_back( partTag );
@@ -593,6 +587,23 @@ void EveChildInstancedMeshes::RemoveInstancesByPartTag( EveSpaceObjectChild::Par
 			}
 		}
 	}
+}
+bool EveChildInstancedMeshes::SetInstanceTransformByPartTag( PartTag partTag, const Vector3& translation, const Quaternion& rotation, Vector3 scale )
+{
+	Matrix m = TransformationMatrix( scale, rotation, translation );
+	bool changed = false;
+	for( auto& mesh : m_meshes )
+	{
+		for( int i = 0; i < mesh.instances.size(); i++ )
+		{
+			if( mesh.partTags[i] == partTag )
+			{
+				mesh.instances[i].SetTransform( m );
+				changed = true;
+			}
+		}
+	}
+	return changed;
 }
 
 void EveChildInstancedMeshes::ReleaseCachedData( BlueAsyncRes* p )
@@ -768,6 +779,32 @@ BluePy EveChildInstancedMeshes::GetSofSourceLocator( uint32_t areaId ) const
 uint32_t EveChildInstancedMeshes::GetMeshCount() const
 {
 	return static_cast<uint32_t>( m_meshes.size() );
+}
+BluePy EveChildInstancedMeshes::GetInstancesTransforms( uint32_t meshId ) const
+{
+	if( meshId >= m_meshes.size() )
+	{
+		PyErr_SetString( PyExc_IndexError, "Mesh index out of range" );
+		return {};
+	}
+
+	auto& mesh = m_meshes[meshId];
+	BluePy result( PyTuple_New( mesh.instances.size() ) );
+	int i = 0;
+	for( auto& instance : mesh.instances )
+	{
+		Vector3 scale, translation;
+		Quaternion rotation;
+		Decompose( scale, rotation, translation, instance.ToMatrix() );
+
+		PyObject* transform = PyTuple_New( 3 );
+		PyTuple_SetItem( transform, 0, ToPython( translation ) );
+		PyTuple_SetItem( transform, 1, ToPython( rotation ) );
+		PyTuple_SetItem( transform, 2, ToPython( scale ) );
+		PyTuple_SetItem( result, i++, transform );
+	}
+
+	return result;
 }
 
 BluePy EveChildInstancedMeshes::GetMeshInfo( uint32_t meshId ) const
@@ -1040,19 +1077,7 @@ void EveChildInstancedMeshes::UpdateOverlayInstanceData( const EveSpaceObjectVSD
 			const auto& wt = mesh.instances[i].worldTransform;
 			OverlayInstancePod& pod = ( *mesh.overlayPods )[i];
 
-			Matrix local = IdentityMatrix();
-			local._11 = wt[0].x;
-			local._12 = wt[1].x;
-			local._13 = wt[2].x;
-			local._21 = wt[0].y;
-			local._22 = wt[1].y;
-			local._23 = wt[2].y;
-			local._31 = wt[0].z;
-			local._32 = wt[1].z;
-			local._33 = wt[2].z;
-			local._41 = wt[0].w;
-			local._42 = wt[1].w;
-			local._43 = wt[2].w;
+			Matrix local = mesh.instances[i].ToMatrix();
 
 			Matrix worldTransform = Transpose( local * m_worldTransform );
 			Matrix worldTransformLast = Transpose( local * prevWorldTransform );

--- a/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.cpp
@@ -588,10 +588,9 @@ void EveChildInstancedMeshes::RemoveInstancesByPartTag( EveSpaceObjectChild::Par
 		}
 	}
 }
-bool EveChildInstancedMeshes::SetInstanceTransformByPartTag( PartTag partTag, const Vector3& translation, const Quaternion& rotation, Vector3 scale )
+void EveChildInstancedMeshes::SetInstanceTransformByPartTag( PartTag partTag, const Vector3& translation, const Quaternion& rotation, Vector3 scale )
 {
 	Matrix m = TransformationMatrix( scale, rotation, translation );
-	bool changed = false;
 	for( auto& mesh : m_meshes )
 	{
 		for( size_t i = 0; i < mesh.instances.size(); ++i )
@@ -599,11 +598,9 @@ bool EveChildInstancedMeshes::SetInstanceTransformByPartTag( PartTag partTag, co
 			if( mesh.partTags[i] == partTag )
 			{
 				mesh.instances[i].SetTransform( m );
-				changed = true;
 			}
 		}
 	}
-	return changed;
 }
 
 void EveChildInstancedMeshes::ReleaseCachedData( BlueAsyncRes* p )

--- a/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.h
+++ b/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.h
@@ -96,11 +96,13 @@ public:
 		EveSpaceObjectChild::PartTag partTag = EveSpaceObjectChild::NO_PART_TAG );
 
 	void RemoveInstancesByPartTag( EveSpaceObjectChild::PartTag partTag );
+	bool SetInstanceTransformByPartTag( PartTag partTag, const Vector3& translation, const Quaternion& rotation, Vector3 scale );
 
 	BluePy GetSofSourceLocator( uint32_t areaId ) const;
 	uint32_t GetMeshCount() const;
 	BluePy GetMeshInfo( uint32_t meshId ) const;
 	BluePy GetAreaInfo( uint32_t meshId, uint32_t areaId ) const;
+	BluePy GetInstancesTransforms( uint32_t meshId ) const;
 	BluePy GetMeshDisplay( uint32_t meshId ) const;
 	BluePy SetMeshDisplay( uint32_t meshId, bool display );
 	BluePy GetMeshInheritOverlayEffects( uint32_t meshId ) const;

--- a/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.h
+++ b/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.h
@@ -96,7 +96,7 @@ public:
 		EveSpaceObjectChild::PartTag partTag = EveSpaceObjectChild::NO_PART_TAG );
 
 	void RemoveInstancesByPartTag( EveSpaceObjectChild::PartTag partTag );
-	bool SetInstanceTransformByPartTag( PartTag partTag, const Vector3& translation, const Quaternion& rotation, Vector3 scale );
+	void SetInstanceTransformByPartTag( PartTag partTag, const Vector3& translation, const Quaternion& rotation, Vector3 scale );
 
 	BluePy GetSofSourceLocator( uint32_t areaId ) const;
 	uint32_t GetMeshCount() const;

--- a/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes_Blue.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes_Blue.cpp
@@ -48,6 +48,14 @@ const Be::ClassInfo* EveChildInstancedMeshes::ExposeToBlue()
 			":param areaId: Index of the area to query\n"
 			":rtype: (trinity.Tr2Effect, int, int, int)" )
 		MAP_METHOD_AND_WRAP(
+			"GetInstancesTransforms",
+			GetInstancesTransforms,
+			"Returns the object-local transform of each instance of an instanced mesh, decomposed\n"
+			"into translation, rotation and scale. Returns one (translation, rotation, scale)\n"
+			"tuple per instance\n\n"
+			":param meshId: Index of the mesh to query\n"
+			":rtype: (((float, float, float), (float, float, float, float), (float, float, float)), ...)" )
+		MAP_METHOD_AND_WRAP(
 			"GetMeshDisplay",
 			GetMeshDisplay,
 			"Returns True if the mesh is rendered, False otherwise\n\n"

--- a/trinity/Eve/SpaceObject/Children/EveChildPartData_Blue.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildPartData_Blue.cpp
@@ -11,6 +11,5 @@ const Be::ClassInfo* EveChildPartData::ExposeToBlue()
 	EXPOSURE_BEGIN( EveChildPartData, "Persistent state of a modular space object (per-part transforms and bounds). Edit through EveModularObjectModifier" )
 		MAP_INTERFACE( EveSpaceObjectChild );
 		MAP_INTERFACE( IEveSpaceObjectChild )
-		MAP_ATTRIBUTE( "name", m_name, "Name of the space object child", Be::READWRITE | Be::PERSIST )
-	EXPOSURE_END()
+	EXPOSURE_CHAINTO( EveSpaceObjectChild )
 }

--- a/trinity/Eve/SpaceObject/Children/EveModularObjectModifier.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveModularObjectModifier.cpp
@@ -222,6 +222,10 @@ BlueStdResult EveModularObjectModifier::SetTransform( EveSpaceObjectChild::PartT
 		{
 			child->Setup( &scale, &rotation, &position, Tr2Lod::TR2_LOD_LOW );
 		}
+		if( EveChildInstancedMeshesPtr instancedMeshes = BlueCastPtr( child ) )
+		{
+			instancedMeshes->SetInstanceTransformByPartTag( partId, position, rotation, scale );
+		}
 	}
 	m_object->InvalidateMergedLocators( LocatorInvalidationReason::PartMoved );
 	return BlueStdResultType::BLUE_STD_RESULT_OK;


### PR DESCRIPTION
fix for https://fenriscreations.atlassian.net/browse/PLAT-11963 which forgot to move the instances

also snuck in evechildpartdata chaining to the root object so graphite doesnt complain about missing name attribute