### PR TITLE
Base system damage locator filtering integration

### DIFF
--- a/trinity/Eve/SpaceObject/Children/EveChildContainer.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildContainer.cpp
@@ -1241,12 +1241,12 @@ void EveChildContainer::CollectOwnedLocatorSets( const Matrix& parentTransform, 
 	}
 }
 
-void EveChildContainer::CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const
+void EveChildContainer::CollectOwnedGeometry( TriBatchType type, const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const
 {
 	Matrix transform = ComputeLocalTransform();
 	transform = transform * parentTransform;
 	for( const auto& object : m_objects )
 	{
-		object->CollectOwnedGeometry( transform, out, areaPool );
+		object->CollectOwnedGeometry( type, transform, out, areaPool );
 	}
 }

--- a/trinity/Eve/SpaceObject/Children/EveChildContainer.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildContainer.cpp
@@ -1241,12 +1241,12 @@ void EveChildContainer::CollectOwnedLocatorSets( const Matrix& parentTransform, 
 	}
 }
 
-void EveChildContainer::CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out ) const
+void EveChildContainer::CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const
 {
 	Matrix transform = ComputeLocalTransform();
 	transform = transform * parentTransform;
 	for( const auto& object : m_objects )
 	{
-		object->CollectOwnedGeometry( transform, out );
+		object->CollectOwnedGeometry( transform, out, areaPool );
 	}
 }

--- a/trinity/Eve/SpaceObject/Children/EveChildContainer.h
+++ b/trinity/Eve/SpaceObject/Children/EveChildContainer.h
@@ -171,7 +171,7 @@ public:
 	bool Empty() const;
 
 	void CollectOwnedLocatorSets( const Matrix& parentTransform, std::vector<EveChildLocatorSetsSource>& out ) const override;
-	void CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const override;
+	void CollectOwnedGeometry( TriBatchType type, const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const override;
 
 	PEveSpaceObjectChildVector m_objects;
 

--- a/trinity/Eve/SpaceObject/Children/EveChildContainer.h
+++ b/trinity/Eve/SpaceObject/Children/EveChildContainer.h
@@ -171,7 +171,7 @@ public:
 	bool Empty() const;
 
 	void CollectOwnedLocatorSets( const Matrix& parentTransform, std::vector<EveChildLocatorSetsSource>& out ) const override;
-	void CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out ) const override;
+	void CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const override;
 
 	PEveSpaceObjectChildVector m_objects;
 

--- a/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.cpp
@@ -1253,7 +1253,7 @@ void EveChildInstancedMeshes::GetBatches( ITriRenderBatchAccumulator* batches, T
 	}
 }
 
-void EveChildInstancedMeshes::CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const
+void EveChildInstancedMeshes::CollectOwnedGeometry( TriBatchType type, const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const
 {
 	for( const Mesh& mesh : m_meshes )
 	{
@@ -1265,16 +1265,16 @@ void EveChildInstancedMeshes::CollectOwnedGeometry( const Matrix& parentTransfor
 		uint32_t areaStart = uint32_t( areaPool.size() );
 		for( const MeshArea& area : mesh.areas )
 		{
-			if( area.batchType != TRIBATCHTYPE_OPAQUE )
+			if( area.batchType != type )
 			{
 				continue;
 			}
-			EveChildGeometryArea occluderArea;
-			occluderArea.index = area.areaIndex;
-			occluderArea.count = area.areaCount;
-			occluderArea.alphaCutout = area.alphaCutout;
-			occluderArea.reversed = area.reversed;
-			areaPool.push_back( occluderArea );
+			EveChildGeometryArea childGeometryArea;
+			childGeometryArea.index = area.areaIndex;
+			childGeometryArea.count = area.areaCount;
+			childGeometryArea.alphaCutout = area.alphaCutout;
+			childGeometryArea.reversed = area.reversed;
+			areaPool.push_back( childGeometryArea );
 		}
 		uint32_t areaCount = uint32_t( areaPool.size() ) - areaStart;
 
@@ -1290,8 +1290,8 @@ void EveChildInstancedMeshes::CollectOwnedGeometry( const Matrix& parentTransfor
 			source.childToObject = instanceTransform * parentTransform;
 			source.geometry = mesh.geometry;
 			source.owner = this;
-			source.opaqueAreaStart = areaStart;
-			source.opaqueAreaCount = areaCount;
+			source.areaStart = areaStart;
+			source.areaCount = areaCount;
 			out.push_back( source );
 		}
 	}

--- a/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.cpp
@@ -1255,9 +1255,13 @@ void EveChildInstancedMeshes::GetBatches( ITriRenderBatchAccumulator* batches, T
 
 void EveChildInstancedMeshes::CollectOwnedGeometry( TriBatchType type, const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const
 {
+	static_assert(
+		sizeof( Float4x3 ) == sizeof( EveInstancedMeshManager::StaticPerInstanceData::worldTransform ),
+		"Float4x3 must match StaticPerInstanceData::worldTransform" );
+
 	for( const Mesh& mesh : m_meshes )
 	{
-		if( !mesh.geometry )
+		if( !mesh.geometry || mesh.instances.empty() )
 		{
 			continue;
 		}
@@ -1289,7 +1293,6 @@ void EveChildInstancedMeshes::CollectOwnedGeometry( TriBatchType type, const Mat
 			EveChildGeometry source;
 			source.childToObject = instanceTransform * parentTransform;
 			source.geometry = mesh.geometry;
-			source.owner = this;
 			source.areaStart = areaStart;
 			source.areaCount = areaCount;
 			out.push_back( source );

--- a/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.cpp
@@ -484,6 +484,8 @@ void EveChildInstancedMeshes::AddMesh(
 		a.batchType = areas[i].batchType;
 		a.areaIndex = areas[i].areaIndex;
 		a.areaCount = areas[i].areaCount;
+		a.alphaCutout = areas[i].alphaCutout;
+		a.reversed = areas[i].reversed;
 		a.effectHash = a.effect ? a.effect->GetHashValue() : 0;
 	}
 	mesh.instances.reserve( count );
@@ -1247,6 +1249,48 @@ void EveChildInstancedMeshes::GetBatches( ITriRenderBatchAccumulator* batches, T
 			{
 				EmitOverlayBatches( batches, pod.framePod, batchType, *m_parentOverlayEffects, mesh.overlayAreaBlocks, *lod );
 			}
+		}
+	}
+}
+
+void EveChildInstancedMeshes::CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out ) const
+{
+	for( const Mesh& mesh : m_meshes )
+	{
+		if( !mesh.geometry )
+		{
+			continue;
+		}
+
+		std::vector<EveChildGeometryArea> opaqueAreas;
+		for( const MeshArea& area : mesh.areas )
+		{
+			if( area.batchType != TRIBATCHTYPE_OPAQUE )
+			{
+				continue;
+			}
+			EveChildGeometryArea occluderArea;
+			occluderArea.index = area.areaIndex;
+			occluderArea.count = area.areaCount;
+			occluderArea.alphaCutout = area.alphaCutout;
+			occluderArea.reversed = area.reversed;
+			opaqueAreas.push_back( occluderArea );
+		}
+
+		if( opaqueAreas.empty() )
+		{
+			continue;
+		}
+
+		for( const auto& instance : mesh.instances )
+		{
+			Matrix instanceTransform = *(Float4x3*)&instance.worldTransform;
+			EveChildGeometry source;
+			source.childToObject = instanceTransform * parentTransform;
+			source.geometry = mesh.geometry;
+			source.owner = this;
+			source.opaqueAreas = opaqueAreas;
+			out.push_back( std::move( source ) );
 		}
 	}
 }

--- a/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.cpp
@@ -1253,7 +1253,7 @@ void EveChildInstancedMeshes::GetBatches( ITriRenderBatchAccumulator* batches, T
 	}
 }
 
-void EveChildInstancedMeshes::CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out ) const
+void EveChildInstancedMeshes::CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const
 {
 	for( const Mesh& mesh : m_meshes )
 	{
@@ -1262,7 +1262,7 @@ void EveChildInstancedMeshes::CollectOwnedGeometry( const Matrix& parentTransfor
 			continue;
 		}
 
-		std::vector<EveChildGeometryArea> opaqueAreas;
+		uint32_t areaStart = uint32_t( areaPool.size() );
 		for( const MeshArea& area : mesh.areas )
 		{
 			if( area.batchType != TRIBATCHTYPE_OPAQUE )
@@ -1274,10 +1274,11 @@ void EveChildInstancedMeshes::CollectOwnedGeometry( const Matrix& parentTransfor
 			occluderArea.count = area.areaCount;
 			occluderArea.alphaCutout = area.alphaCutout;
 			occluderArea.reversed = area.reversed;
-			opaqueAreas.push_back( occluderArea );
+			areaPool.push_back( occluderArea );
 		}
+		uint32_t areaCount = uint32_t( areaPool.size() ) - areaStart;
 
-		if( opaqueAreas.empty() )
+		if( areaCount == 0 )
 		{
 			continue;
 		}
@@ -1289,8 +1290,9 @@ void EveChildInstancedMeshes::CollectOwnedGeometry( const Matrix& parentTransfor
 			source.childToObject = instanceTransform * parentTransform;
 			source.geometry = mesh.geometry;
 			source.owner = this;
-			source.opaqueAreas = opaqueAreas;
-			out.push_back( std::move( source ) );
+			source.opaqueAreaStart = areaStart;
+			source.opaqueAreaCount = areaCount;
+			out.push_back( source );
 		}
 	}
 }

--- a/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.h
+++ b/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.h
@@ -76,6 +76,8 @@ public:
 		TriBatchType batchType = TRIBATCHTYPE_OPAQUE;
 		uint32_t areaIndex = 0;
 		uint32_t areaCount = 1;
+		bool alphaCutout = false;
+		bool reversed = false;
 		uint64_t effectHash = 0;
 		EveInstancedMeshManager::MeshGroupHandle meshGroupHandle;
 	};
@@ -108,6 +110,8 @@ public:
 	BluePy RemoveMeshOverlayEffect( uint32_t meshId, EveMeshOverlayEffect* overlayEffect );
 	BluePy ClearMeshOverlayEffects( uint32_t meshId );
 	BluePy GetMeshOverlayEffectCount( uint32_t meshId ) const;
+
+	void CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out ) const override;
 
 private:
 	// per-instance constant buffers for overlay draws

--- a/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.h
+++ b/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.h
@@ -111,7 +111,7 @@ public:
 	BluePy ClearMeshOverlayEffects( uint32_t meshId );
 	BluePy GetMeshOverlayEffectCount( uint32_t meshId ) const;
 
-	void CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out ) const override;
+	void CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const override;
 
 private:
 	// per-instance constant buffers for overlay draws

--- a/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.h
+++ b/trinity/Eve/SpaceObject/Children/EveChildInstancedMeshes.h
@@ -111,7 +111,7 @@ public:
 	BluePy ClearMeshOverlayEffects( uint32_t meshId );
 	BluePy GetMeshOverlayEffectCount( uint32_t meshId ) const;
 
-	void CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const override;
+	void CollectOwnedGeometry( TriBatchType type, const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const override;
 
 private:
 	// per-instance constant buffers for overlay draws

--- a/trinity/Eve/SpaceObject/Children/EveChildMesh.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildMesh.cpp
@@ -2070,7 +2070,6 @@ void EveChildMesh::CollectOwnedGeometry( TriBatchType type, const Matrix& parent
 	EveChildGeometry source;
 	source.childToObject = localTransform * parentTransform;
 	source.geometry = m_mesh->GetGeometryResource();
-	source.owner = this;
 	source.areaStart = uint32_t( areaPool.size() );
 	EveCollectAreas( type, m_mesh, areaPool );
 	source.areaCount = uint32_t( areaPool.size() ) - source.areaStart;

--- a/trinity/Eve/SpaceObject/Children/EveChildMesh.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildMesh.cpp
@@ -2058,7 +2058,7 @@ void EveChildMesh::CollectOwnedLocatorSets( const Matrix& parentTransform, std::
 	}
 }
 
-void EveChildMesh::CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out ) const
+void EveChildMesh::CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const
 {
 	if( !m_mesh || !m_mesh->GetGeometryResource() )
 	{
@@ -2071,8 +2071,10 @@ void EveChildMesh::CollectOwnedGeometry( const Matrix& parentTransform, std::vec
 	source.childToObject = localTransform * parentTransform;
 	source.geometry = m_mesh->GetGeometryResource();
 	source.owner = this;
-	source.opaqueAreas = EveCollectOccluderAreas( m_mesh );
-	out.push_back( std::move( source ) );
+	source.opaqueAreaStart = uint32_t( areaPool.size() );
+	EveCollectOccluderAreas( m_mesh, areaPool );
+	source.opaqueAreaCount = uint32_t( areaPool.size() ) - source.opaqueAreaStart;
+	out.push_back( source );
 }
 
 void EveChildMesh::SetOwnedLocatorSets( const std::vector<EveLocatorSetsPtr>& sets )

--- a/trinity/Eve/SpaceObject/Children/EveChildMesh.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildMesh.cpp
@@ -2058,7 +2058,7 @@ void EveChildMesh::CollectOwnedLocatorSets( const Matrix& parentTransform, std::
 	}
 }
 
-void EveChildMesh::CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const
+void EveChildMesh::CollectOwnedGeometry( TriBatchType type, const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const
 {
 	if( !m_mesh || !m_mesh->GetGeometryResource() )
 	{
@@ -2071,9 +2071,9 @@ void EveChildMesh::CollectOwnedGeometry( const Matrix& parentTransform, std::vec
 	source.childToObject = localTransform * parentTransform;
 	source.geometry = m_mesh->GetGeometryResource();
 	source.owner = this;
-	source.opaqueAreaStart = uint32_t( areaPool.size() );
-	EveCollectOccluderAreas( m_mesh, areaPool );
-	source.opaqueAreaCount = uint32_t( areaPool.size() ) - source.opaqueAreaStart;
+	source.areaStart = uint32_t( areaPool.size() );
+	EveCollectAreas( type, m_mesh, areaPool );
+	source.areaCount = uint32_t( areaPool.size() ) - source.areaStart;
 	out.push_back( source );
 }
 

--- a/trinity/Eve/SpaceObject/Children/EveChildMesh.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildMesh.cpp
@@ -2071,8 +2071,8 @@ void EveChildMesh::CollectOwnedGeometry( const Matrix& parentTransform, std::vec
 	source.childToObject = localTransform * parentTransform;
 	source.geometry = m_mesh->GetGeometryResource();
 	source.owner = this;
-	source.mesh = m_mesh;
-	out.push_back( source );
+	source.opaqueAreas = EveCollectOccluderAreas( m_mesh );
+	out.push_back( std::move( source ) );
 }
 
 void EveChildMesh::SetOwnedLocatorSets( const std::vector<EveLocatorSetsPtr>& sets )

--- a/trinity/Eve/SpaceObject/Children/EveChildMesh.h
+++ b/trinity/Eve/SpaceObject/Children/EveChildMesh.h
@@ -198,7 +198,7 @@ public:
 	BluePy GetSofSourceLocator( uint32_t areaId ) const;
 
 	void CollectOwnedLocatorSets( const Matrix& parentTransform, std::vector<EveChildLocatorSetsSource>& out ) const override;
-	void CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out ) const override;
+	void CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const override;
 	void SetOwnedLocatorSets( const std::vector<EveLocatorSetsPtr>& sets );
 	void InvalidateOwnerMergedLocators( LocatorInvalidationReason reason );
 

--- a/trinity/Eve/SpaceObject/Children/EveChildMesh.h
+++ b/trinity/Eve/SpaceObject/Children/EveChildMesh.h
@@ -198,7 +198,7 @@ public:
 	BluePy GetSofSourceLocator( uint32_t areaId ) const;
 
 	void CollectOwnedLocatorSets( const Matrix& parentTransform, std::vector<EveChildLocatorSetsSource>& out ) const override;
-	void CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const override;
+	void CollectOwnedGeometry( TriBatchType type, const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const override;
 	void SetOwnedLocatorSets( const std::vector<EveLocatorSetsPtr>& sets );
 	void InvalidateOwnerMergedLocators( LocatorInvalidationReason reason );
 

--- a/trinity/Eve/SpaceObject/Children/EveSpaceObjectChild.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveSpaceObjectChild.cpp
@@ -131,18 +131,24 @@ void EveSpaceObjectChild::CollectOwnedLocatorSets( const Matrix& parentTransform
 {
 }
 
-void EveSpaceObjectChild::CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const
+void EveSpaceObjectChild::CollectOwnedGeometry( TriBatchType type, const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const
 {
 }
 
-void EveCollectOccluderAreas( Tr2MeshBase* mesh, std::vector<EveChildGeometryArea>& areaPool )
+void EveCollectAreas( TriBatchType type, Tr2MeshBase* mesh, std::vector<EveChildGeometryArea>& areaPool )
 {
 	if( !mesh )
 	{
 		return;
 	}
 
-	Tr2MeshAreaVector* areas = mesh->GetAreas( TRIBATCHTYPE_OPAQUE );
+	Tr2MeshAreaVector* areas = mesh->GetAreas( type );
+
+	if( !areas )
+	{
+		return;
+	}
+
 	for( auto it = begin( *areas ); it != end( *areas ); it++ )
 	{
 		EveChildGeometryArea area;

--- a/trinity/Eve/SpaceObject/Children/EveSpaceObjectChild.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveSpaceObjectChild.cpp
@@ -2,6 +2,7 @@
 
 #include "StdAfx.h"
 #include "EveSpaceObjectChild.h"
+#include "Tr2MeshBase.h"
 
 
 EveSpaceObjectChild::EveSpaceObjectChild( IRoot* )
@@ -132,6 +133,27 @@ void EveSpaceObjectChild::CollectOwnedLocatorSets( const Matrix& parentTransform
 
 void EveSpaceObjectChild::CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out ) const
 {
+}
+
+std::vector<EveChildGeometryArea> EveCollectOccluderAreas( Tr2MeshBase* mesh )
+{
+	std::vector<EveChildGeometryArea> occluderAreas;
+	if( !mesh )
+	{
+		return occluderAreas;
+	}
+
+	Tr2MeshAreaVector* areas = mesh->GetAreas( TRIBATCHTYPE_OPAQUE );
+	for( auto it = begin( *areas ); it != end( *areas ); it++ )
+	{
+		EveChildGeometryArea area;
+		area.index = uint32_t( ( *it )->GetIndex() );
+		area.count = uint32_t( ( *it )->GetCount() );
+		area.alphaCutout = ( *it )->IsAlphaCutout();
+		area.reversed = ( *it )->IsReversed();
+		occluderAreas.push_back( area );
+	}
+	return occluderAreas;
 }
 
 void EveSpaceObjectChild::RegisterChild( EveSpaceObjectChild* child )

--- a/trinity/Eve/SpaceObject/Children/EveSpaceObjectChild.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveSpaceObjectChild.cpp
@@ -131,16 +131,15 @@ void EveSpaceObjectChild::CollectOwnedLocatorSets( const Matrix& parentTransform
 {
 }
 
-void EveSpaceObjectChild::CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out ) const
+void EveSpaceObjectChild::CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const
 {
 }
 
-std::vector<EveChildGeometryArea> EveCollectOccluderAreas( Tr2MeshBase* mesh )
+void EveCollectOccluderAreas( Tr2MeshBase* mesh, std::vector<EveChildGeometryArea>& areaPool )
 {
-	std::vector<EveChildGeometryArea> occluderAreas;
 	if( !mesh )
 	{
-		return occluderAreas;
+		return;
 	}
 
 	Tr2MeshAreaVector* areas = mesh->GetAreas( TRIBATCHTYPE_OPAQUE );
@@ -151,9 +150,8 @@ std::vector<EveChildGeometryArea> EveCollectOccluderAreas( Tr2MeshBase* mesh )
 		area.count = uint32_t( ( *it )->GetCount() );
 		area.alphaCutout = ( *it )->IsAlphaCutout();
 		area.reversed = ( *it )->IsReversed();
-		occluderAreas.push_back( area );
+		areaPool.push_back( area );
 	}
-	return occluderAreas;
 }
 
 void EveSpaceObjectChild::RegisterChild( EveSpaceObjectChild* child )

--- a/trinity/Eve/SpaceObject/Children/EveSpaceObjectChild.h
+++ b/trinity/Eve/SpaceObject/Children/EveSpaceObjectChild.h
@@ -33,7 +33,7 @@ struct EveChildGeometryArea
 };
 
 /**
- * @brief Struct bundling geometry and owner information as well as transform, to be processed by the parent object.
+ * @brief Struct bundling geometry and transform, to be processed by the parent object.
  * The geometry's areas live in the pool passed to CollectOwnedGeometry.
  * @see EveSpaceObjectChild::CollectOwnedGeometry
  */
@@ -41,7 +41,6 @@ struct EveChildGeometry
 {
 	class TriGeometryRes* geometry = nullptr;
 	Matrix childToObject = IdentityMatrix();
-	const class EveSpaceObjectChild* owner = nullptr;
 	uint32_t areaStart = 0;
 	uint32_t areaCount = 0;
 };

--- a/trinity/Eve/SpaceObject/Children/EveSpaceObjectChild.h
+++ b/trinity/Eve/SpaceObject/Children/EveSpaceObjectChild.h
@@ -33,6 +33,7 @@ struct EveChildGeometryArea
 
 /**
  * @brief Struct bundling geometry and owner information as well as transform, to be processed by the parent object.
+ * The geometry's opaque areas live in the pool passed to CollectOwnedGeometry.
  * @see EveSpaceObjectChild::CollectOwnedGeometry
  */
 struct EveChildGeometry
@@ -40,13 +41,14 @@ struct EveChildGeometry
 	class TriGeometryRes* geometry = nullptr;
 	Matrix childToObject = IdentityMatrix();
 	const class EveSpaceObjectChild* owner = nullptr;
-	std::vector<EveChildGeometryArea> opaqueAreas;
+	uint32_t opaqueAreaStart = 0;
+	uint32_t opaqueAreaCount = 0;
 };
 
 /**
- * @brief Collects opaque areas from a mesh.
+ * @brief Appends the opaque areas of a mesh to the given area pool.
  */
-std::vector<EveChildGeometryArea> EveCollectOccluderAreas( class Tr2MeshBase* mesh );
+void EveCollectOccluderAreas( class Tr2MeshBase* mesh, std::vector<EveChildGeometryArea>& areaPool );
 
 /**
  * @brief Base class for all space object children. This class provides common functionality and properties for all child objects in the space object hierarchy.
@@ -283,8 +285,9 @@ public:
 	 * @brief Collects all geometries that are owned by this child, so they can be processed by the parent object.
 	 * @param parentTransform The parent's transform, which is to be applied on the locators.
 	 * @param out The collected geometries, bundled with owner information and transforms.
+	 * @param areaPool Pool receiving the opaque areas of the collected geometries.
 	 */
-	virtual void CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out ) const;
+	virtual void CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const;
 
 protected:
 	/**

--- a/trinity/Eve/SpaceObject/Children/EveSpaceObjectChild.h
+++ b/trinity/Eve/SpaceObject/Children/EveSpaceObjectChild.h
@@ -18,6 +18,20 @@ struct EveChildLocatorSetsSource
 };
 
 /**
+ * @brief Struct containing information about mesh areas.
+ * @see EveSpaceObjectChild::CollectOwnedGeometry
+ * @see Tr2MeshArea
+ * @see EveChildInstancedMeshes::MeshArea
+ */
+struct EveChildGeometryArea
+{
+	uint32_t index = 0;
+	uint32_t count = 1;
+	bool alphaCutout = false;
+	bool reversed = false;
+};
+
+/**
  * @brief Struct bundling geometry and owner information as well as transform, to be processed by the parent object.
  * @see EveSpaceObjectChild::CollectOwnedGeometry
  */
@@ -25,9 +39,14 @@ struct EveChildGeometry
 {
 	class TriGeometryRes* geometry = nullptr;
 	Matrix childToObject = IdentityMatrix();
-	const class EveChildMesh* owner = nullptr;
-	class Tr2MeshBase* mesh = nullptr;
+	const class EveSpaceObjectChild* owner = nullptr;
+	std::vector<EveChildGeometryArea> opaqueAreas;
 };
+
+/**
+ * @brief Collects opaque areas from a mesh.
+ */
+std::vector<EveChildGeometryArea> EveCollectOccluderAreas( class Tr2MeshBase* mesh );
 
 /**
  * @brief Base class for all space object children. This class provides common functionality and properties for all child objects in the space object hierarchy.

--- a/trinity/Eve/SpaceObject/Children/EveSpaceObjectChild.h
+++ b/trinity/Eve/SpaceObject/Children/EveSpaceObjectChild.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "IEveSpaceObjectChild.h"
+#include "ITr2Renderable.h"
 
 BLUE_CLASS_IMPL( EveSpaceObjectChild );
 
@@ -33,7 +34,7 @@ struct EveChildGeometryArea
 
 /**
  * @brief Struct bundling geometry and owner information as well as transform, to be processed by the parent object.
- * The geometry's opaque areas live in the pool passed to CollectOwnedGeometry.
+ * The geometry's areas live in the pool passed to CollectOwnedGeometry.
  * @see EveSpaceObjectChild::CollectOwnedGeometry
  */
 struct EveChildGeometry
@@ -41,14 +42,14 @@ struct EveChildGeometry
 	class TriGeometryRes* geometry = nullptr;
 	Matrix childToObject = IdentityMatrix();
 	const class EveSpaceObjectChild* owner = nullptr;
-	uint32_t opaqueAreaStart = 0;
-	uint32_t opaqueAreaCount = 0;
+	uint32_t areaStart = 0;
+	uint32_t areaCount = 0;
 };
 
 /**
- * @brief Appends the opaque areas of a mesh to the given area pool.
+ * @brief Appends the areas of a mesh to the given area pool.
  */
-void EveCollectOccluderAreas( class Tr2MeshBase* mesh, std::vector<EveChildGeometryArea>& areaPool );
+void EveCollectAreas( TriBatchType type, class Tr2MeshBase* mesh, std::vector<EveChildGeometryArea>& areaPool );
 
 /**
  * @brief Base class for all space object children. This class provides common functionality and properties for all child objects in the space object hierarchy.
@@ -283,11 +284,12 @@ public:
 
 	/**
 	 * @brief Collects all geometries that are owned by this child, so they can be processed by the parent object.
+	 * @param type The type of geometry that will be collected.
 	 * @param parentTransform The parent's transform, which is to be applied on the locators.
 	 * @param out The collected geometries, bundled with owner information and transforms.
-	 * @param areaPool Pool receiving the opaque areas of the collected geometries.
+	 * @param areaPool Pool receiving the areas of the collected geometries.
 	 */
-	virtual void CollectOwnedGeometry( const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const;
+	virtual void CollectOwnedGeometry( TriBatchType type, const Matrix& parentTransform, std::vector<EveChildGeometry>& out, std::vector<EveChildGeometryArea>& areaPool ) const;
 
 protected:
 	/**

--- a/trinity/Eve/SpaceObject/EveSpaceObject2.cpp
+++ b/trinity/Eve/SpaceObject/EveSpaceObject2.cpp
@@ -1963,6 +1963,7 @@ void EveSpaceObject2::ReleaseDamageFilterSessions()
 		}
 
 		m_damageFilterOccluders.clear();
+		m_damageFilterAreas.clear();
 	}
 }
 
@@ -1975,6 +1976,7 @@ bool EveSpaceObject2::CollectOccluders()
 		if( !m_mesh->GetGeometryResource()->IsPrepared() )
 		{
 			m_damageFilterOccluders.clear();
+			m_damageFilterAreas.clear();
 			return false;
 		}
 
@@ -1983,8 +1985,10 @@ bool EveSpaceObject2::CollectOccluders()
 			DamageFilterOccluder occluder;
 			occluder.geometry = m_mesh->GetGeometryResource();
 			occluder.fromObject = IdentityMatrix();
-			occluder.opaqueAreas = EveCollectOccluderAreas( m_mesh );
-			if( !occluder.opaqueAreas.empty() )
+			occluder.opaqueAreaStart = uint32_t( m_damageFilterAreas.size() );
+			EveCollectOccluderAreas( m_mesh, m_damageFilterAreas );
+			occluder.opaqueAreaCount = uint32_t( m_damageFilterAreas.size() ) - occluder.opaqueAreaStart;
+			if( occluder.opaqueAreaCount != 0 )
 			{
 				m_damageFilterOccluders.push_back( std::move( occluder ) );
 			}
@@ -1994,12 +1998,12 @@ bool EveSpaceObject2::CollectOccluders()
 	std::vector<EveChildGeometry> childGeometries;
 	for( auto& child : m_effectChildren )
 	{
-		child->CollectOwnedGeometry( IdentityMatrix(), childGeometries );
+		child->CollectOwnedGeometry( IdentityMatrix(), childGeometries, m_damageFilterAreas );
 	}
 
 	for( auto& childGeometry : childGeometries )
 	{
-		if( childGeometry.opaqueAreas.empty() )
+		if( childGeometry.opaqueAreaCount == 0 )
 		{
 			continue;
 		}
@@ -2007,6 +2011,7 @@ bool EveSpaceObject2::CollectOccluders()
 		if( !childGeometry.geometry->IsPrepared() )
 		{
 			m_damageFilterOccluders.clear();
+			m_damageFilterAreas.clear();
 			return false;
 		}
 
@@ -2018,7 +2023,8 @@ bool EveSpaceObject2::CollectOccluders()
 		DamageFilterOccluder occluder;
 		occluder.geometry = childGeometry.geometry;
 		occluder.fromObject = Inverse( childGeometry.childToObject );
-		occluder.opaqueAreas = std::move( childGeometry.opaqueAreas );
+		occluder.opaqueAreaStart = childGeometry.opaqueAreaStart;
+		occluder.opaqueAreaCount = childGeometry.opaqueAreaCount;
 		m_damageFilterOccluders.push_back( std::move( occluder ) );
 	}
 
@@ -2079,7 +2085,7 @@ void EveSpaceObject2::RefreshDamageLocatorMask( const LocatorStructureList* dama
 
 		for( auto& occluder : m_damageFilterOccluders )
 		{
-			if( occluder.opaqueAreas.empty() )
+			if( occluder.opaqueAreaCount == 0 )
 			{
 				continue;
 			}
@@ -2100,8 +2106,9 @@ void EveSpaceObject2::RefreshDamageLocatorMask( const LocatorStructureList* dama
 			// That larger distance is in our object space!
 			// So rayLength is always in object space, and can safely be compared with frontFaceMinDistance. :)
 
-			for( const EveChildGeometryArea& area : occluder.opaqueAreas )
+			for( uint32_t poolIndex = occluder.opaqueAreaStart; poolIndex < occluder.opaqueAreaStart + occluder.opaqueAreaCount; poolIndex++ )
 			{
+				const EveChildGeometryArea& area = m_damageFilterAreas[poolIndex];
 				for( uint32_t areaIndex = area.index; areaIndex < area.index + area.count; areaIndex++ )
 				{
 					// We only trace up to the distance of the closest intersection that we have found so far.

--- a/trinity/Eve/SpaceObject/EveSpaceObject2.cpp
+++ b/trinity/Eve/SpaceObject/EveSpaceObject2.cpp
@@ -1985,10 +1985,10 @@ bool EveSpaceObject2::CollectOccluders()
 			DamageFilterOccluder occluder;
 			occluder.geometry = m_mesh->GetGeometryResource();
 			occluder.fromObject = IdentityMatrix();
-			occluder.opaqueAreaStart = uint32_t( m_damageFilterAreas.size() );
-			EveCollectOccluderAreas( m_mesh, m_damageFilterAreas );
-			occluder.opaqueAreaCount = uint32_t( m_damageFilterAreas.size() ) - occluder.opaqueAreaStart;
-			if( occluder.opaqueAreaCount != 0 )
+			occluder.areaStart = uint32_t( m_damageFilterAreas.size() );
+			EveCollectAreas( TRIBATCHTYPE_OPAQUE, m_mesh, m_damageFilterAreas );
+			occluder.areaCount = uint32_t( m_damageFilterAreas.size() ) - occluder.areaStart;
+			if( occluder.areaCount != 0 )
 			{
 				m_damageFilterOccluders.push_back( std::move( occluder ) );
 			}
@@ -1998,12 +1998,12 @@ bool EveSpaceObject2::CollectOccluders()
 	std::vector<EveChildGeometry> childGeometries;
 	for( auto& child : m_effectChildren )
 	{
-		child->CollectOwnedGeometry( IdentityMatrix(), childGeometries, m_damageFilterAreas );
+		child->CollectOwnedGeometry( TRIBATCHTYPE_OPAQUE, IdentityMatrix(), childGeometries, m_damageFilterAreas );
 	}
 
 	for( auto& childGeometry : childGeometries )
 	{
-		if( childGeometry.opaqueAreaCount == 0 )
+		if( childGeometry.areaCount == 0 )
 		{
 			continue;
 		}
@@ -2023,8 +2023,8 @@ bool EveSpaceObject2::CollectOccluders()
 		DamageFilterOccluder occluder;
 		occluder.geometry = childGeometry.geometry;
 		occluder.fromObject = Inverse( childGeometry.childToObject );
-		occluder.opaqueAreaStart = childGeometry.opaqueAreaStart;
-		occluder.opaqueAreaCount = childGeometry.opaqueAreaCount;
+		occluder.areaStart = childGeometry.areaStart;
+		occluder.areaCount = childGeometry.areaCount;
 		m_damageFilterOccluders.push_back( std::move( occluder ) );
 	}
 
@@ -2085,7 +2085,7 @@ void EveSpaceObject2::RefreshDamageLocatorMask( const LocatorStructureList* dama
 
 		for( auto& occluder : m_damageFilterOccluders )
 		{
-			if( occluder.opaqueAreaCount == 0 )
+			if( occluder.areaCount == 0 )
 			{
 				continue;
 			}
@@ -2106,7 +2106,7 @@ void EveSpaceObject2::RefreshDamageLocatorMask( const LocatorStructureList* dama
 			// That larger distance is in our object space!
 			// So rayLength is always in object space, and can safely be compared with frontFaceMinDistance. :)
 
-			for( uint32_t poolIndex = occluder.opaqueAreaStart; poolIndex < occluder.opaqueAreaStart + occluder.opaqueAreaCount; poolIndex++ )
+			for( uint32_t poolIndex = occluder.areaStart; poolIndex < occluder.areaStart + occluder.areaCount; poolIndex++ )
 			{
 				const EveChildGeometryArea& area = m_damageFilterAreas[poolIndex];
 				for( uint32_t areaIndex = area.index; areaIndex < area.index + area.count; areaIndex++ )

--- a/trinity/Eve/SpaceObject/EveSpaceObject2.cpp
+++ b/trinity/Eve/SpaceObject/EveSpaceObject2.cpp
@@ -1983,8 +1983,11 @@ bool EveSpaceObject2::CollectOccluders()
 			DamageFilterOccluder occluder;
 			occluder.geometry = m_mesh->GetGeometryResource();
 			occluder.fromObject = IdentityMatrix();
-			occluder.mesh = m_mesh;
-			m_damageFilterOccluders.push_back( occluder );
+			occluder.opaqueAreas = EveCollectOccluderAreas( m_mesh );
+			if( !occluder.opaqueAreas.empty() )
+			{
+				m_damageFilterOccluders.push_back( std::move( occluder ) );
+			}
 		}
 	}
 
@@ -1996,6 +1999,11 @@ bool EveSpaceObject2::CollectOccluders()
 
 	for( auto& childGeometry : childGeometries )
 	{
+		if( childGeometry.opaqueAreas.empty() )
+		{
+			continue;
+		}
+
 		if( !childGeometry.geometry->IsPrepared() )
 		{
 			m_damageFilterOccluders.clear();
@@ -2010,8 +2018,8 @@ bool EveSpaceObject2::CollectOccluders()
 		DamageFilterOccluder occluder;
 		occluder.geometry = childGeometry.geometry;
 		occluder.fromObject = Inverse( childGeometry.childToObject );
-		occluder.mesh = childGeometry.mesh;
-		m_damageFilterOccluders.push_back( occluder );
+		occluder.opaqueAreas = std::move( childGeometry.opaqueAreas );
+		m_damageFilterOccluders.push_back( std::move( occluder ) );
 	}
 
 	for( auto& occluder : m_damageFilterOccluders )
@@ -2071,40 +2079,48 @@ void EveSpaceObject2::RefreshDamageLocatorMask( const LocatorStructureList* dama
 
 		for( auto& occluder : m_damageFilterOccluders )
 		{
-			auto areas = occluder.mesh->GetAreas( TRIBATCHTYPE_OPAQUE );
-			if( !areas->empty() )
+			if( occluder.opaqueAreas.empty() )
 			{
-				Vector3 rayOrigin = Transform( origin, occluder.fromObject ).GetXYZ();
-				Vector3 rayDirection = TransformNormal( direction, occluder.fromObject );
+				continue;
+			}
 
-				// Note that we deliberately don't normalize the rayDirection.
-				//
-				// We transform the 'direction' from object space to child space to compute 'rayDirection'.
-				// A child, that has been scaled to a large size, will get a small rayDirection.
-				// After all, we go from object space to child space, so we transform rayDirection with the inverse child scale!
-				//
-				// The intersection function will then find an intersection at a proportionally larger distance.
-				// Consider the line equation: intersectionPoint = distance * rayDirection + rayOrigin
-				// If rayDirection is small, then distance has to be larger to compensate.
-				//
-				// That larger distance is in our object space!
-				// So rayLength is always in object space, and can safely be compared with frontFaceMinDistance. :)
+			Vector3 rayOrigin = Transform( origin, occluder.fromObject ).GetXYZ();
+			Vector3 rayDirection = TransformNormal( direction, occluder.fromObject );
 
-				for( auto it = begin( *areas ); it != end( *areas ); ++it )
+			// Note that we deliberately don't normalize the rayDirection.
+			//
+			// We transform the 'direction' from object space to child space to compute 'rayDirection'.
+			// A child, that has been scaled to a large size, will get a small rayDirection.
+			// After all, we go from object space to child space, so we transform rayDirection with the inverse child scale!
+			//
+			// The intersection function will then find an intersection at a proportionally larger distance.
+			// Consider the line equation: intersectionPoint = distance * rayDirection + rayOrigin
+			// If rayDirection is small, then distance has to be larger to compensate.
+			//
+			// That larger distance is in our object space!
+			// So rayLength is always in object space, and can safely be compared with frontFaceMinDistance. :)
+
+			for( const EveChildGeometryArea& area : occluder.opaqueAreas )
+			{
+				for( uint32_t areaIndex = area.index; areaIndex < area.index + area.count; areaIndex++ )
 				{
 					// We only trace up to the distance of the closest intersection that we have found so far.
 					RayCastResult hitInfo;
-					if( occluder.geometry->GetIntersectionPoints( rayOrigin, rayDirection, hitInfo, ( *it )->GetIndex(), rayLength ) )
+					if( occluder.geometry->GetIntersectionPoints( rayOrigin, rayDirection, hitInfo, areaIndex, rayLength ) )
 					{
 						rayLength = hitInfo.distance;
 						// TRIBATCHTYPE_OPAQUE also contains alpha cutouts, which can be one-sided. Ignore them to prevent false positives.
-						backfacing = !( *it )->IsAlphaCutout() && ( ( Dot( hitInfo.unnormalizedNormal, rayDirection ) > 0 ) != ( *it )->IsReversed() );
+						backfacing = !area.alphaCutout && ( ( Dot( hitInfo.unnormalizedNormal, rayDirection ) > 0 ) != area.reversed );
 						if( rayLength < frontFaceMinDistance )
 						{
 							occluded = true;
 							break;
 						}
 					}
+				}
+				if( occluded )
+				{
+					break;
 				}
 			}
 			if( occluded )

--- a/trinity/Eve/SpaceObject/EveSpaceObject2.h
+++ b/trinity/Eve/SpaceObject/EveSpaceObject2.h
@@ -183,7 +183,7 @@ struct DamageFilterOccluder
 {
 	TriGeometryResPtr geometry;
 	Matrix fromObject;
-	Tr2MeshBasePtr mesh;
+	std::vector<EveChildGeometryArea> opaqueAreas;
 };
 
 // ---------------------------------------------------------------------------------------

--- a/trinity/Eve/SpaceObject/EveSpaceObject2.h
+++ b/trinity/Eve/SpaceObject/EveSpaceObject2.h
@@ -183,7 +183,8 @@ struct DamageFilterOccluder
 {
 	TriGeometryResPtr geometry;
 	Matrix fromObject;
-	std::vector<EveChildGeometryArea> opaqueAreas;
+	uint32_t opaqueAreaStart = 0;
+	uint32_t opaqueAreaCount = 0;
 };
 
 // ---------------------------------------------------------------------------------------
@@ -821,6 +822,7 @@ private:
 	bool m_damageLocatorAutoFilterEnabled; // For debugging purposes: Shall we run damage locator filtering whenever parts are moved?
 	bool m_damageLocatorFilterRequested; // Did someone request filtering damage locator?
 	std::vector<DamageFilterOccluder> m_damageFilterOccluders; // Occluders used during damage locator filtering (geometry to raycast against).
+	std::vector<EveChildGeometryArea> m_damageFilterAreas; // Areas referenced by m_damageFilterOccluders.
 	enum class DamageFilterState // State machine for damage locator filtering, since we have to wait on stuff before we can start raycasting.
 	{
 		Idle, // No need to run filtering this frame.

--- a/trinity/Eve/SpaceObject/EveSpaceObject2.h
+++ b/trinity/Eve/SpaceObject/EveSpaceObject2.h
@@ -183,8 +183,8 @@ struct DamageFilterOccluder
 {
 	TriGeometryResPtr geometry;
 	Matrix fromObject;
-	uint32_t opaqueAreaStart = 0;
-	uint32_t opaqueAreaCount = 0;
+	uint32_t areaStart = 0;
+	uint32_t areaCount = 0;
 };
 
 // ---------------------------------------------------------------------------------------

--- a/trinity/Eve/SpaceObjectFactory/EveSOF.cpp
+++ b/trinity/Eve/SpaceObjectFactory/EveSOF.cpp
@@ -428,7 +428,13 @@ bool EveSOF::BuildChild( EveSpaceObject2* newObj, const char* dnaString, uint32_
 			{
 				auto effect = area->GetMaterialInterface();
 				effect->SetOption( BlueSharedString( "SPACE_OBJECT_INSTANCED_ATTACHMENT" ), BlueSharedString( "SOIA_SHARED" ) );
-				areas.push_back( EveChildInstancedMeshes::MeshArea{ effect, type == TRIBATCHTYPE_DECAL ? TRIBATCHTYPE_OPAQUE : type, uint32_t( area->GetIndex() ), uint32_t( area->GetCount() ) } );
+				areas.push_back( EveChildInstancedMeshes::MeshArea{
+					effect,
+					type == TRIBATCHTYPE_DECAL ? TRIBATCHTYPE_OPAQUE : type,
+					uint32_t( area->GetIndex() ),
+					uint32_t( area->GetCount() ),
+					area->IsAlphaCutout(),
+					area->IsReversed() } );
 			}
 		}
 		sharedMeshes->AddMesh(
@@ -3903,7 +3909,13 @@ void EveSOF::CreatePlacement(
 				{
 					auto effect = area->GetMaterialInterface();
 					effect->SetOption( BlueSharedString( "SPACE_OBJECT_INSTANCED_ATTACHMENT" ), BlueSharedString( "SOIA_SHARED" ) );
-					areas.push_back( EveChildInstancedMeshes::MeshArea{ effect, type == TRIBATCHTYPE_DECAL ? TRIBATCHTYPE_OPAQUE : type, uint32_t( area->GetIndex() ), uint32_t( area->GetCount() ) } );
+					areas.push_back( EveChildInstancedMeshes::MeshArea{
+						effect,
+						type == TRIBATCHTYPE_DECAL ? TRIBATCHTYPE_OPAQUE : type,
+						uint32_t( area->GetIndex() ),
+						uint32_t( area->GetCount() ),
+						area->IsAlphaCutout(),
+						area->IsReversed() } );
 				}
 			}
 			sharedMeshes->AddMesh(


### PR DESCRIPTION
Integration of damage locator filtering with base system.
It doesn't work with EveChildInstancedMeshes without this.