### PR TITLE
fix aces sweetener option

### DIFF
--- a/trinity/PostProcess/Tr2PostProcessRenderer.cpp
+++ b/trinity/PostProcess/Tr2PostProcessRenderer.cpp
@@ -434,7 +434,7 @@ void ApplyAcesTonemappingMethod( const Tr2PPTonemappingEffect* tonemapping, Tr2E
 {
 	tonemappingEffect->SetOption( MEMOIZED_STRING( "TONE_MAPPING_METHOD" ), MEMOIZED_STRING( "TONE_MAPPING_ACES" ) );
 
-	static BlueSharedString blueOption = tonemapping->m_aces.m_useSweeteners ? MEMOIZED_STRING( "SWEETENER_ENABLED" ) : MEMOIZED_STRING( "SWEETENER_DISABLED" );
+	BlueSharedString blueOption = tonemapping->m_aces.m_useSweeteners ? MEMOIZED_STRING( "SWEETENER_ENABLED" ) : MEMOIZED_STRING( "SWEETENER_DISABLED" );
 	tonemappingEffect->SetOption( MEMOIZED_STRING( "SWEETENER_TOGGLE" ), blueOption );
 	tonemappingEffect->SetParameter( MEMOIZED_STRING( "AcesSlope" ), tonemapping->m_aces.m_slope );
 	tonemappingEffect->SetParameter( MEMOIZED_STRING( "AcesToe" ), tonemapping->m_aces.m_toe );


### PR DESCRIPTION
Alongside MEMOIZED_STRING a bug was introduced where a variable was declared as static that should not have been.

