### PR TITLE
Fix CAS sharpening clamping scene colors to [0-1] range

### DIFF
--- a/trinity/Eve/EveSpaceScene.cpp
+++ b/trinity/Eve/EveSpaceScene.cpp
@@ -368,6 +368,7 @@ void EveSpaceScene::UpdatePostProcessAttributes()
 		{
 			m_combinedPostProcess.CreateInstance();
 		}
+		m_combinedPostProcess->m_sharpeningStrength = m_sceneDefaultPostProcess->m_sharpeningStrength;
 
 		std::sort(
 			begin( postProcessAttributes ),

--- a/trinity/Eve/EveSpaceScene.cpp
+++ b/trinity/Eve/EveSpaceScene.cpp
@@ -368,7 +368,7 @@ void EveSpaceScene::UpdatePostProcessAttributes()
 		{
 			m_combinedPostProcess.CreateInstance();
 		}
-		m_combinedPostProcess->m_sharpeningStrength = m_sceneDefaultPostProcess->m_sharpeningStrength;
+		m_combinedPostProcess->m_sharpeningStrength = m_sceneDefaultPostProcess ? m_sceneDefaultPostProcess->m_sharpeningStrength : 0.5f;
 
 		std::sort(
 			begin( postProcessAttributes ),

--- a/trinity/PostProcess/Tr2PostProcess2.h
+++ b/trinity/PostProcess/Tr2PostProcess2.h
@@ -86,6 +86,7 @@ public:
 	float GetMipLodBias() const;
 
 	float m_exposureAdjustment = 0;
+	float m_sharpeningStrength = 0.5f;
 
 private:
 	Tr2PPSignalLossEffectPtr m_signalLoss;

--- a/trinity/PostProcess/Tr2PostProcess2_Blue.cpp
+++ b/trinity/PostProcess/Tr2PostProcess2_Blue.cpp
@@ -28,5 +28,7 @@ const Be::ClassInfo* Tr2PostProcess2::ExposeToBlue()
 		MAP_ATTRIBUTE( "colorCorrection", m_colorCorrection, "Accesses the color correction effect", Be::READWRITE | Be::PERSIST )
 		MAP_ATTRIBUTE( "genericEffect", m_generic, "Accesses the generic effect", Be::READWRITE | Be::PERSIST )
 
+		MAP_ATTRIBUTE( "sharpeningStrength", m_sharpeningStrength, "CAS sharpening strength: from 0 to 1", Be::READWRITE | Be::PERSIST )
+
 	EXPOSURE_END()
 }

--- a/trinity/PostProcess/Tr2PostProcessRenderer.cpp
+++ b/trinity/PostProcess/Tr2PostProcessRenderer.cpp
@@ -684,10 +684,10 @@ void Tr2PostProcessRenderer::Execute(
 	{
 		displaySize = { upscalingInfo.displayWidth, upscalingInfo.displayHeight };
 	}
-	Tr2GpuResourcePool::Texture output = gpuResourcePool.GetTempTexture( 
-		"Final Result", 
-		displaySize, 
-		sharpeningRequired ? GetUavCompatibleFormat( destination.GetFormat() ) : destination.GetFormat(), 
+	Tr2GpuResourcePool::Texture output = gpuResourcePool.GetTempTexture(
+		"Final Result",
+		displaySize,
+		sharpeningRequired ? GetUavCompatibleFormat( destination.GetFormat() ) : destination.GetFormat(),
 		sharpeningRequired ? RENDER_TARGET | Tr2GpuUsage::UNORDERED_ACCESS : RENDER_TARGET );
 
 	// Always copy
@@ -811,18 +811,18 @@ void Tr2PostProcessRenderer::Execute(
 			scene->ApplyUpscalingToPerFrameData( displaySize.width, displaySize.height, renderContext );
 			if( sharpeningRequired )
 			{
-				RenderSharpening( postProcess->m_sharpeningStrength, upscaled, output, gpuResourcePool, renderContext );
+				RenderSharpening( postProcess->m_sharpeningStrength, upscaled, output, renderContext );
 			}
 			else
 			{
 				output = upscaled;
 			}
 		}
-		else if ( sharpeningRequired )
+		else if( sharpeningRequired )
 		{
 			auto tonemappedOutput = gpuResourcePool.GetTempTexture( "Tonemapping Result", displaySize, upscaledSource->GetFormat(), RENDER_TARGET );
 			RenderTonemapping( tonemappedOutput, postProcess, renderContext );
-			RenderSharpening( postProcess->m_sharpeningStrength, tonemappedOutput, output, gpuResourcePool, renderContext );
+			RenderSharpening( postProcess->m_sharpeningStrength, tonemappedOutput, output, renderContext );
 		}
 		else
 		{
@@ -838,11 +838,11 @@ void Tr2PostProcessRenderer::Execute(
 			Tr2Renderer::DrawTexture( renderContext, output );
 		}
 	}
-	else if ( sharpeningRequired )
+	else if( sharpeningRequired )
 	{
 		auto tonemappedOutput = gpuResourcePool.GetTempTexture( "Tonemapping Result", displaySize, upscaledSource->GetFormat(), RENDER_TARGET );
 		RenderTonemapping( tonemappedOutput, postProcess, renderContext );
-		RenderSharpening( postProcess->m_sharpeningStrength, tonemappedOutput, output, gpuResourcePool, renderContext );
+		RenderSharpening( postProcess->m_sharpeningStrength, tonemappedOutput, output, renderContext );
 		Tr2Renderer::DrawTexture( renderContext, output );
 	}
 	else
@@ -873,7 +873,7 @@ void Tr2PostProcessRenderer::SetupExposureConversion( bool enable, float middleV
 	}
 }
 
-void Tr2PostProcessRenderer::RenderSharpening( float strength, Tr2GpuResourcePool::Texture& input, Tr2GpuResourcePool::Texture& output, Tr2GpuResourcePool& gpuResourcePool, Tr2RenderContext& renderContext )
+void Tr2PostProcessRenderer::RenderSharpening( float strength, Tr2GpuResourcePool::Texture& input, Tr2GpuResourcePool::Texture& output, Tr2RenderContext& renderContext )
 {
 	GPU_REGION( renderContext, "CAS Sharpening" );
 

--- a/trinity/PostProcess/Tr2PostProcessRenderer.cpp
+++ b/trinity/PostProcess/Tr2PostProcessRenderer.cpp
@@ -678,19 +678,17 @@ void Tr2PostProcessRenderer::Execute(
 	const auto upscalingInfo = renderContext.GetPrimaryRenderContext().GetUpscalingInfo( upscalingContext ? upscalingContext->GetID() : Tr2UpscalingAL::INVALID_CONTEXT_ID );
 
 	auto upscalingEnabled = upscalingInfo.technique != Tr2UpscalingAL::NONE;
-	bool sharpeningRequired = !upscalingInfo.hasSharpening;
+	bool sharpeningRequired = postProcess ? !upscalingInfo.hasSharpening && postProcess->m_sharpeningStrength > 0.f : false;
 
-	Tr2GpuResourcePool::Texture output;
 	if( upscalingEnabled )
 	{
 		displaySize = { upscalingInfo.displayWidth, upscalingInfo.displayHeight };
-
-		output = gpuResourcePool.GetTempTexture( "Final Result", displaySize, destination.GetFormat(), RENDER_TARGET );
 	}
-	else
-	{
-		output = gpuResourcePool.GetTempTexture( "Final Result", displaySize, destination.GetFormat(), RENDER_TARGET );
-	}
+	Tr2GpuResourcePool::Texture output = gpuResourcePool.GetTempTexture( 
+		"Final Result", 
+		displaySize, 
+		sharpeningRequired ? GetUavCompatibleFormat( destination.GetFormat() ) : destination.GetFormat(), 
+		sharpeningRequired ? RENDER_TARGET | Tr2GpuUsage::UNORDERED_ACCESS : RENDER_TARGET );
 
 	// Always copy
 	auto nonMsaaSource = gpuResourcePool.GetTempTexture( "Pre-upscaling Composite", renderSize, sourceBuffer->GetFormat(), RENDER_TARGET );
@@ -787,12 +785,11 @@ void Tr2PostProcessRenderer::Execute(
 		}
 	}
 
-	upscaledSource = RenderSharpening( sharpeningRequired, upscaledSource, gpuResourcePool, renderContext );
-
 	TEMP_PARAM( m_tonemappingEffect, "BlitCurrent", bloomTexture );
 	TEMP_PARAM( m_tonemappingEffect, "BlitOriginal", upscaledSource );
 	TEMP_PARAM( m_tonemappingEffect, "Exposure", GetExposureBuffer( gpuResourcePool ) );
 	TEMP_PARAM( m_tonemappingEffect, "Histogram", histogramBuffer );
+	m_tonemappingEffect->SetParameter( MEMOIZED_STRING( "DitherStrength" ), sharpeningRequired ? 0.f : 1.f );
 
 	Tr2PPFilmGrainEffect* filmGrain = postProcess != nullptr ? postProcess->GetFilmGrainIfAvailable( m_quality ) : nullptr;
 
@@ -801,23 +798,36 @@ void Tr2PostProcessRenderer::Execute(
 		GPU_REGION( renderContext, "Tonemapping" );
 		if( upscalingContext && !upscalingInfo.temporal )
 		{
-			auto tonemappedOutput = gpuResourcePool.GetTempTexture( "Tonemapping Result", renderSize, destination.GetFormat(), RENDER_TARGET );
+			auto tonemappedOutput = gpuResourcePool.GetTempTexture( "Tonemapping Result", renderSize, sharpeningRequired ? upscaledSource->GetFormat() : destination.GetFormat(), RENDER_TARGET );
 
 			RenderTonemapping( tonemappedOutput, postProcess, renderContext );
 
-			output = RenderUpscaling( tonemappedOutput, depthMap, velocity, opaqueColor, scene->GetReprojectionMatrix(), gpuResourcePool, renderContext, upscalingContext, dynamicExposure );
+			auto upscaled = RenderUpscaling( tonemappedOutput, depthMap, velocity, opaqueColor, scene->GetReprojectionMatrix(), gpuResourcePool, renderContext, upscalingContext, dynamicExposure );
 			depthMap = {};
 			velocity = {};
 			opaqueColor = {};
 
 			// need to reset the perframedata so we have the correct viewport size etc
 			scene->ApplyUpscalingToPerFrameData( displaySize.width, displaySize.height, renderContext );
+			if( sharpeningRequired )
+			{
+				RenderSharpening( postProcess->m_sharpeningStrength, upscaled, output, gpuResourcePool, renderContext );
+			}
+			else
+			{
+				output = upscaled;
+			}
+		}
+		else if ( sharpeningRequired )
+		{
+			auto tonemappedOutput = gpuResourcePool.GetTempTexture( "Tonemapping Result", displaySize, upscaledSource->GetFormat(), RENDER_TARGET );
+			RenderTonemapping( tonemappedOutput, postProcess, renderContext );
+			RenderSharpening( postProcess->m_sharpeningStrength, tonemappedOutput, output, gpuResourcePool, renderContext );
 		}
 		else
 		{
 			RenderTonemapping( output, postProcess, renderContext );
 		}
-
 		renderContext.m_esm.SetRenderTarget( 0, destination );
 		if( filmGrain != nullptr )
 		{
@@ -827,6 +837,13 @@ void Tr2PostProcessRenderer::Execute(
 		{
 			Tr2Renderer::DrawTexture( renderContext, output );
 		}
+	}
+	else if ( sharpeningRequired )
+	{
+		auto tonemappedOutput = gpuResourcePool.GetTempTexture( "Tonemapping Result", displaySize, upscaledSource->GetFormat(), RENDER_TARGET );
+		RenderTonemapping( tonemappedOutput, postProcess, renderContext );
+		RenderSharpening( postProcess->m_sharpeningStrength, tonemappedOutput, output, gpuResourcePool, renderContext );
+		Tr2Renderer::DrawTexture( renderContext, output );
 	}
 	else
 	{
@@ -856,27 +873,20 @@ void Tr2PostProcessRenderer::SetupExposureConversion( bool enable, float middleV
 	}
 }
 
-Tr2GpuResourcePool::Texture Tr2PostProcessRenderer::RenderSharpening( bool enable, Tr2GpuResourcePool::Texture& input, Tr2GpuResourcePool& gpuResourcePool, Tr2RenderContext& renderContext )
+void Tr2PostProcessRenderer::RenderSharpening( float strength, Tr2GpuResourcePool::Texture& input, Tr2GpuResourcePool::Texture& output, Tr2GpuResourcePool& gpuResourcePool, Tr2RenderContext& renderContext )
 {
-	if( !enable )
-	{
-		return input;
-	}
 	GPU_REGION( renderContext, "CAS Sharpening" );
 
 	static const uint32_t CAS_THREAD_GROUP_WORK_REGION_DIM = 16;
-	auto format = GetUavCompatibleFormat( input->GetFormat() );
-	auto output = gpuResourcePool.GetTempTexture( "Sharpening Output", input->GetWidth(), input->GetHeight(), format, RENDER_TARGET | Tr2GpuUsage::UNORDERED_ACCESS );
 
 	auto renderWidth = output->GetWidth();
 	auto renderHeight = output->GetHeight();
 	AF1 outWidth = static_cast<AF1>( renderWidth );
 	AF1 outHeight = static_cast<AF1>( renderHeight );
-	float casIntensity = 0.0f;
 
 	AMDSharpening::CASConstants casConst;
 
-	CasSetup( casConst.const0.u, casConst.const1.u, casIntensity, outWidth, outHeight, outWidth, outHeight );
+	CasSetup( casConst.const0.u, casConst.const1.u, std::clamp( strength, 0.0f, 1.0f ), outWidth, outHeight, outWidth, outHeight );
 
 	m_fidelityFxCasShader->SetParameter( MEMOIZED_STRING( "const0" ), AMDSharpening::AsVector( casConst.const0 ) );
 	m_fidelityFxCasShader->SetParameter( MEMOIZED_STRING( "const1" ), AMDSharpening::AsVector( casConst.const1 ) );
@@ -886,7 +896,6 @@ Tr2GpuResourcePool::Texture Tr2PostProcessRenderer::RenderSharpening( bool enabl
 	auto dispatchX = ( renderWidth + ( CAS_THREAD_GROUP_WORK_REGION_DIM - 1 ) ) / CAS_THREAD_GROUP_WORK_REGION_DIM;
 	auto dispatchY = ( renderHeight + ( CAS_THREAD_GROUP_WORK_REGION_DIM - 1 ) ) / CAS_THREAD_GROUP_WORK_REGION_DIM;
 	Tr2Renderer::RunComputeShader( m_fidelityFxCasShader, dispatchX, dispatchY, 1, renderContext );
-	return output;
 }
 
 // Helper function to blur certain channel of a source render target to a destination render target with a blur type (Big/Small)

--- a/trinity/PostProcess/Tr2PostProcessRenderer.h
+++ b/trinity/PostProcess/Tr2PostProcessRenderer.h
@@ -147,7 +147,7 @@ private:
 	void SetupExposureConversion( bool enable, float middleValue );
 
 	// optional sharpening
-	void RenderSharpening( float strength, Tr2GpuResourcePool::Texture& input, Tr2GpuResourcePool::Texture& output, Tr2GpuResourcePool& gpuResourcePool, Tr2RenderContext& renderContext );
+	void RenderSharpening( float strength, Tr2GpuResourcePool::Texture& input, Tr2GpuResourcePool::Texture& output, Tr2RenderContext& renderContext );
 
 	// bloom
 	Tr2GpuResourcePool::Texture RenderBloom( Tr2GpuResourcePool::Texture & dest, Tr2GpuResourcePool & gpuResourcePool, Tr2RenderContext & renderContext, Tr2PPBloomEffect * bloom, Tr2PPDynamicExposureEffect * dynamicExposure );

--- a/trinity/PostProcess/Tr2PostProcessRenderer.h
+++ b/trinity/PostProcess/Tr2PostProcessRenderer.h
@@ -147,7 +147,7 @@ private:
 	void SetupExposureConversion( bool enable, float middleValue );
 
 	// optional sharpening
-	Tr2GpuResourcePool::Texture RenderSharpening( bool enable, Tr2GpuResourcePool::Texture& input, Tr2GpuResourcePool& gpuResourcePool, Tr2RenderContext& renderContext );
+	void RenderSharpening( float strength, Tr2GpuResourcePool::Texture& input, Tr2GpuResourcePool::Texture& output, Tr2GpuResourcePool& gpuResourcePool, Tr2RenderContext& renderContext );
 
 	// bloom
 	Tr2GpuResourcePool::Texture RenderBloom( Tr2GpuResourcePool::Texture & dest, Tr2GpuResourcePool & gpuResourcePool, Tr2RenderContext & renderContext, Tr2PPBloomEffect * bloom, Tr2PPDynamicExposureEffect * dynamicExposure );


### PR DESCRIPTION
## Summary

Move CAS sharpening pass in the post-process pipeline to be executed after tonemapping.

## Details

The issue observed is that scene colors are clamped to [0-1] range before exposure and tonemapping due to CAS sharpening pass: CAS expects linear colors in [0-1] range for both input and output.

The issue was introduced in v3.6.4 when sharpening was moved to be before tonemapping, and the reason for the move was that sharpening is amplifying dithering added to tonemapping. 

This PR moves sharpening back to its original place. Dithering performed by the tonemapping shader is now supposed to happen in CAS shader (after sharpening). Tonemapping may still need to perform dithering if CAS sharpening is disabled. Trinity now passes `DitherStrength` parameter to the tonemapping shader (either 0 or 1), and the shader is supposed to disable dithering if the parameter is zero.

To perform dithering correctly, the output of the tonemapping shader (if CAS is enabled) needs to be of higher precision, so post-processing uses the source texture format for it. 

On top of the fix, the PR exposes a sharpening strength attribute on the `Tr2PostProcess2` object, so that projects can tweak this value. It was decided that this value only needs to be tweakable globally per-project, and there is no need to have it in post-process volumes.

Note on implementation. There are more changes to Tr2PostProcessRenderer.cpp than I would like. The reason for it is that the `output` texture needs to be set as the "hudless texture" for upscaling (for frame generation), and the code needs to make sure that throughout all the branches, the result of post-processing ends up in that texture.

## Shader changes

**This PR needs corresponding shader changes to tonemapping and CAS sharpening**

## Task link

https://fenriscreations.atlassian.net/browse/PLAT-11873

