### PR TITLE
fix damage locator bone transform

### DIFF
--- a/trinity/Eve/SpaceObject/Attachments/EveImpactOverlay.cpp
+++ b/trinity/Eve/SpaceObject/Attachments/EveImpactOverlay.cpp
@@ -186,7 +186,7 @@ void EveImpactOverlay::UpdateAsyncronous( const EveUpdateContext& updateContext,
 	info.estimatedPixelDiameter = parent->GetEstimatedPixelDiameter();
 	info.isInFrustum = parent->IsInFrustum();
 	info.getDamageLocatorPositionOS = [parent]( int index, Vector3& out ) {
-		return parent->GetDamageLocatorPosition( &out, index, false );
+		return parent->GetDamageLocatorBindPosition( index, out );
 	};
 	m_damageOverlay->UpdateAsyncronous( updateContext, info, m_shieldImpactData.size(), HasShieldActivity() );
 

--- a/trinity/Eve/SpaceObject/Children/EveChildMesh.cpp
+++ b/trinity/Eve/SpaceObject/Children/EveChildMesh.cpp
@@ -1127,7 +1127,7 @@ void EveChildMesh::UpdateAsyncronous( const EveUpdateContext& updateContext, con
 		info.estimatedPixelDiameter = max( m_currentScreenSize, 0.f );
 		info.isInFrustum = m_isVisible;
 		info.getDamageLocatorPositionOS = [this]( int index, Vector3& out ) {
-			return GetDamageLocatorPositionLocal( index, out );
+			return GetDamageLocatorBindPositionLocal( index, out );
 		};
 		m_damageOverlay->UpdateAsyncronous( updateContext, info, 0, false );
 	}
@@ -2104,38 +2104,38 @@ EveDamageOverlayPtr EveChildMesh::EnsureDamageOverlay()
 	return m_damageOverlay;
 }
 
-bool EveChildMesh::GetDamageLocatorPositionLocal( int index, Vector3& out ) const
+const LocatorStructureList* EveChildMesh::GetOwnedDamageLocators() const
 {
-	if( index < 0 )
-	{
-		return false;
-	}
-
 	for( const auto& sets : m_ownedLocatorSets )
 	{
 		if( sets->HasName( DAMAGE_LOCATOR_SET_NAME ) )
 		{
-			const LocatorStructureList* locators = sets->GetLocators();
-			if( index >= int( locators->size() ) )
-			{
-				return false;
-			}
-
-			const Locator& locator = ( *locators )[index];
-			out = locator.position;
-
-			// for reference, see EveSpaceObject2::GetLocatorInObjectSpace
-			if( locator.boneIndex > 0 && m_animationUpdater && m_animationUpdater->IsInitialized() &&
-				locator.boneIndex < m_animationUpdater->GetMeshBoneCount() )
-			{
-				const Float4x3* bones = m_animationUpdater->GetMeshBoneMatrixList();
-				Matrix transform = IdentityMatrix();
-				TriMatrixCopyFrom3x4( &transform, &bones[locator.boneIndex] );
-				out = XMVector3TransformCoord( locator.position, transform );
-			}
-
-			return true;
+			return sets->GetLocators();
 		}
 	}
-	return false;
+	return nullptr;
+}
+
+bool EveChildMesh::GetDamageLocatorBindPositionLocal( int index, Vector3& out ) const
+{
+	const LocatorStructureList* locators = GetOwnedDamageLocators();
+	if( !locators || index < 0 || index >= int( locators->size() ) )
+	{
+		return false;
+	}
+
+	out = ( *locators )[index].position;
+	return true;
+}
+
+bool EveChildMesh::GetDamageLocatorAnimatedLocal( int index, Vector3& position, Vector3& direction ) const
+{
+	const LocatorStructureList* locators = GetOwnedDamageLocators();
+	if( !locators || index < 0 || index >= int( locators->size() ) )
+	{
+		return false;
+	}
+
+	EveGetLocatorPose( m_animationUpdater, ( *locators )[index], position, direction );
+	return true;
 }

--- a/trinity/Eve/SpaceObject/Children/EveChildMesh.h
+++ b/trinity/Eve/SpaceObject/Children/EveChildMesh.h
@@ -204,9 +204,12 @@ public:
 
 	EveDamageOverlayPtr GetDamageOverlay() const;
 	EveDamageOverlayPtr EnsureDamageOverlay();
-	bool GetDamageLocatorPositionLocal( int index, Vector3& out ) const;
+	bool GetDamageLocatorBindPositionLocal( int index, Vector3& out ) const;
+	bool GetDamageLocatorAnimatedLocal( int index, Vector3& position, Vector3& direction ) const;
 
 protected:
+	const LocatorStructureList* GetOwnedDamageLocators() const;
+
 	virtual void ReleaseResources( TriStorage s );
 	virtual bool OnPrepareResources();
 

--- a/trinity/Eve/SpaceObject/EveSpaceObject2.cpp
+++ b/trinity/Eve/SpaceObject/EveSpaceObject2.cpp
@@ -1015,29 +1015,18 @@ void EveSpaceObject2::RenderDebugInfo( ITr2DebugRenderer2& renderer )
 			for( size_t i = 0; i < locators.size(); ++i )
 			{
 				auto& locator = locators[i];
-				auto position = locator.position;
-				auto rotation = locator.direction;
 
-				size_t boneCount;
-				const Float4x3* bones;
+				Vector3 position;
+				Vector3 direction;
+				GetLocatorInObjectSpace( position, direction, locator, isDamageLocatorSet ? int( i ) : -1 );
 
 				Color locatorColor = c;
 
-				if( locator.boneIndex >= 0 && Tr2GrannyAnimationUtils::GetBoneList( m_animationUpdater, bones, boneCount ) )
+				size_t boneCount;
+				const Float4x3* bones;
+				if( Tr2GrannyAnimationUtils::GetBoneList( m_animationUpdater, bones, boneCount ) && locator.boneIndex >= int( boneCount ) )
 				{
-					if( locator.boneIndex < int( boneCount ) )
-					{
-						const Float4x3* bones = m_animationUpdater->GetMeshBoneMatrixList();
-						Matrix boneTF = IdentityMatrix();
-						TriMatrixCopyFrom3x4( &boneTF, &bones[locator.boneIndex] );
-						position = XMVector3TransformCoord( position, boneTF );
-
-						rotation = XMQuaternionMultiply( rotation, XMQuaternionRotationMatrix( boneTF ) );
-					}
-					else
-					{
-						locatorColor = 0x99ff4444;
-					}
+					locatorColor = 0x99ff4444;
 				}
 
 				if( isDamageLocatorSet && i < m_damageLocatorEnabled.size() && !m_damageLocatorEnabled[i] )
@@ -1049,7 +1038,7 @@ void EveSpaceObject2::RenderDebugInfo( ITr2DebugRenderer2& renderer )
 				renderer.DrawSphereArrow(
 					Tr2DebugObjectReference( &locators, uint32_t( i ) ),
 					Vector3( XMVector3TransformCoord( position, m_worldTransform ) ),
-					Vector3( XMVector3TransformNormal( Vector3( 0, 1, 0 ), Matrix( XMMatrixRotationQuaternion( rotation ) ) * m_worldTransform ) ),
+					Vector3( XMVector3TransformNormal( direction, m_worldTransform ) ),
 					min( m_boundingSphereRadius * m_modelScale / 50.f, 100.0f ),
 					8,
 					Tr2DebugRenderer::Lit,

--- a/trinity/Eve/SpaceObject/EveSpaceObject2.cpp
+++ b/trinity/Eve/SpaceObject/EveSpaceObject2.cpp
@@ -205,7 +205,7 @@ EveSpaceObject2::EveSpaceObject2( IRoot* lockobj ) :
 	m_mergedLocatorSetsDirty( true ),
 	m_damageLocatorAutoFilterEnabled( false ),
 	m_damageLocatorFilterRequested( false ),
-	m_damageFilterState( DamageFilterState::Pending )
+	m_damageFilterState( DamageFilterState::Idle )
 {
 	m_positionDelta.CreateInstance();
 
@@ -1946,6 +1946,7 @@ void EveSpaceObject2::EnsureChildLocatorMerged() const
 			range.partTag = childLocatorSet.owner->GetPartTag();
 			range.start = int32_t( ( *mergedLocatorSet )->GetLocators()->size() - childLocatorSet.sets->GetLocators()->size() );
 			range.count = int32_t( childLocatorSet.sets->GetLocators()->size() );
+			range.childToObject = childLocatorSet.childToObject;
 			m_mergedDamageLocatorSources.push_back( range );
 		}
 	}
@@ -2621,7 +2622,7 @@ int EveSpaceObject2::GetClosestLocatorIndex( const Vector3* position, BlueShared
 		}
 
 		auto& locator = ( *locators )[i];
-		GetLocatorInObjectSpace( locatorPosition, locatorDirection, locator );
+		GetLocatorInObjectSpace( locatorPosition, locatorDirection, locator, isDamageLocatorSet ? int( i ) : -1 );
 		if( IsLocatorFacingPosition( locatorDirection, posInObjectSpace ) )
 		{
 			auto distanceFromLocator = LengthSq( locatorPosition - posInObjectSpace );
@@ -2664,7 +2665,7 @@ int EveSpaceObject2::GetCloseLocatorIndex( const Vector3& position, BlueSharedSt
 		}
 
 		auto& locator = ( *locators )[i];
-		GetLocatorInObjectSpace( locatorPosition, locatorDirection, locator );
+		GetLocatorInObjectSpace( locatorPosition, locatorDirection, locator, isDamageLocatorSet ? int( i ) : -1 );
 
 		auto distanceFromLocator = LengthSq( locatorPosition - posInObjectSpace );
 		if( distanceFromLocator < closestLength )
@@ -2734,7 +2735,7 @@ int EveSpaceObject2::GetGoodLocatorIndex( const Vector3& position, BlueSharedStr
 		}
 
 		auto& locator = ( *locators )[i];
-		GetLocatorInObjectSpace( locatorPosition, locatorDirection, locator );
+		GetLocatorInObjectSpace( locatorPosition, locatorDirection, locator, isDamageLocatorSet ? int( i ) : -1 );
 		if( IsLocatorFacingPosition( locatorDirection, posInObjectSpace ) )
 		{
 			Vector3 v( XMVectorSubtract( locatorPosition, posInObjectSpace ) );
@@ -2759,7 +2760,7 @@ int EveSpaceObject2::GetGoodLocatorIndex( const Vector3& position, BlueSharedStr
 		}
 
 		auto& locator = ( *locators )[i];
-		GetLocatorInObjectSpace( locatorPosition, locatorDirection, locator );
+		GetLocatorInObjectSpace( locatorPosition, locatorDirection, locator, isDamageLocatorSet ? int( i ) : -1 );
 		if( IsLocatorFacingPosition( locatorDirection, posInObjectSpace ) )
 		{
 			Vector3 v( XMVectorSubtract( locatorPosition, posInObjectSpace ) );
@@ -2790,6 +2791,19 @@ float EveSpaceObject2::GetRadius() const
 bool EveSpaceObject2::GetDamageLocatorPosition( Vector3* out, int index, bool inWorldSpace )
 {
 	return GetLocatorPosition( out, index, inWorldSpace, DAMAGE_LOCATOR_SET_NAME );
+}
+
+bool EveSpaceObject2::GetDamageLocatorBindPosition( int index, Vector3& out ) const
+{
+	auto damageLocators = GetLocatorsForSet( DAMAGE_LOCATOR_SET_NAME );
+	if( !damageLocators || index < 0 || index >= int( damageLocators->size() ) )
+	{
+		out = Vector3( 0.f, 0.f, 0.f );
+		return false;
+	}
+
+	out = ( *damageLocators )[index].position;
+	return true;
 }
 
 Vector3 EveSpaceObject2::GetLocatorPositionFromSet( int index, bool inWorldSpace, BlueSharedString locatorSetName )
@@ -2823,7 +2837,7 @@ bool EveSpaceObject2::GetLocatorPosition( Vector3* out, int index, bool inWorldS
 	const Locator& locator = ( *locators )[index];
 
 	Vector3 position, direction;
-	GetLocatorInObjectSpace( position, direction, locator );
+	GetLocatorInObjectSpace( position, direction, locator, locatorSetName == DAMAGE_LOCATOR_SET_NAME ? index : -1 );
 
 	if( inWorldSpace )
 	{
@@ -2966,7 +2980,7 @@ bool EveSpaceObject2::GetLocatorDirection( Vector3* out, int index, bool inWorld
 	const Locator& locator = ( *locators )[index];
 
 	Vector3 position, direction;
-	GetLocatorInObjectSpace( position, direction, locator );
+	GetLocatorInObjectSpace( position, direction, locator, locatorSetName == DAMAGE_LOCATOR_SET_NAME ? index : -1 );
 
 	if( inWorldSpace )
 	{
@@ -3706,7 +3720,7 @@ Vector3 EveSpaceObject2::GetDamageLocator( uint32_t index ) const
 	const Locator& damageLocator = ( *damageLocators )[index];
 
 	Vector3 position, direction;
-	GetLocatorInObjectSpace( position, direction, damageLocator );
+	GetLocatorInObjectSpace( position, direction, damageLocator, int( index ) );
 
 	return position;
 }
@@ -3720,13 +3734,13 @@ Vector3 EveSpaceObject2::GetDamageLocatorDirectionLocal( uint32_t index ) const
 	}
 	const Locator& damageLocator = ( *damageLocators )[index];
 	Vector3 position, direction;
-	GetLocatorInObjectSpace( position, direction, damageLocator );
+	GetLocatorInObjectSpace( position, direction, damageLocator, int( index ) );
 	return direction;
 }
 
 // --------------------------------------------------------------------------------
 // Description:
-//   Returns the damage locator positionin worldspace
+//   Returns the damage locator position in worldspace
 // --------------------------------------------------------------------------------
 Vector3 EveSpaceObject2::GetTransformedDamageLocator( uint32_t index )
 {
@@ -3740,35 +3754,32 @@ Vector3 EveSpaceObject2::GetTransformedDamageLocator( uint32_t index )
 	const Locator& damageLocator = ( *damageLocators )[index];
 
 	Vector3 position, direction;
-	GetLocatorInObjectSpace( position, direction, damageLocator );
+	GetLocatorInObjectSpace( position, direction, damageLocator, int( index ) );
 
 	return XMVector3TransformCoord( position, m_worldTransform );
 }
 
-void EveSpaceObject2::GetLocatorInObjectSpace( Vector3& position, Vector3& direction, const Locator& locator ) const
+void EveSpaceObject2::GetLocatorInObjectSpace( Vector3& position, Vector3& direction, const Locator& locator, int mergedDamageIndex ) const
 {
-	Vector3 damagelocatorDirection = (Vector3)XMVector3Rotate( Vector3( 0.f, 1.f, 0.f ), locator.direction );
-	// We're assuming for now that the bone 0 isn't animated for performance reasons.
-	if( locator.boneIndex <= 0 )
+	if( mergedDamageIndex >= 0 )
 	{
-		// damage locator is not attached to a bone, return the position
-		position = locator.position;
-		direction = damagelocatorDirection;
-		return;
-	}
-
-	// If the damage locator is animated we extract the bone matrix and apply it to the damage locator position
-	if( m_animationUpdater && m_animationUpdater->IsInitialized() )
-	{
-		if( locator.boneIndex < m_animationUpdater->GetMeshBoneCount() )
+		EnsureChildLocatorMerged();
+		for( const auto& range : m_mergedDamageLocatorSources )
 		{
-			const Float4x3* bones = m_animationUpdater->GetMeshBoneMatrixList();
-			Matrix boneTF = IdentityMatrix();
-			TriMatrixCopyFrom3x4( &boneTF, &bones[locator.boneIndex] );
-			position = XMVector3TransformCoord( locator.position, boneTF );
-			direction = XMVector3TransformNormal( damagelocatorDirection, boneTF );
+			if( range.owner && mergedDamageIndex >= range.start && mergedDamageIndex < range.start + range.count )
+			{
+				if( range.owner->GetDamageLocatorAnimatedLocal( mergedDamageIndex - range.start, position, direction ) )
+				{
+					position = XMVector3TransformCoord( position, range.childToObject );
+					direction = Normalize( (Vector3)XMVector3TransformNormal( direction, range.childToObject ) );
+					return;
+				}
+				break;
+			}
 		}
 	}
+
+	EveGetLocatorPose( m_animationUpdater, locator, position, direction );
 }
 
 Be::Result<std::string> EveSpaceObject2::GetLocalBoundingBoxFromScript( std::pair<Vector3, Vector3>& result )

--- a/trinity/Eve/SpaceObject/EveSpaceObject2.h
+++ b/trinity/Eve/SpaceObject/EveSpaceObject2.h
@@ -177,6 +177,7 @@ struct LocatorSourceRange
 	int32_t count;
 	const class EveChildMesh* owner;
 	uint32_t partTag;
+	Matrix childToObject = IdentityMatrix();
 };
 
 struct DamageFilterOccluder
@@ -354,6 +355,7 @@ public:
 	unsigned int GetDamageLocatorCount() const;
 	int GetClosestDamageLocatorIndex( const Vector3* position );
 	virtual bool GetDamageLocatorPosition( Vector3 * out, int index, bool inWorldSpace );
+	bool GetDamageLocatorBindPosition( int index, Vector3& out ) const;
 	virtual bool GetDamageLocatorDirection( Vector3 * out, int index, bool inWorldSpace );
 	void GetMissPosition( const Vector3* hit, const Vector3* source, Vector3* out );
 	int GetGoodDamageLocatorIndex( const Vector3& position );
@@ -762,7 +764,9 @@ protected:
 
 	/////////////////////////////////////////////////////////////////////////////////////
 	// Object space damage locator information
-	virtual void GetLocatorInObjectSpace( Vector3 & position, Vector3 & direction, const Locator& locator ) const;
+	// Pass the locator's index in the merged damage locator set as mergedDamageIndex so that
+	// locators owned by a child part get the child's bone pose applied; -1 for other sets.
+	virtual void GetLocatorInObjectSpace( Vector3 & position, Vector3 & direction, const Locator& locator, int mergedDamageIndex = -1 ) const;
 
 
 	/////////////////////////////////////////////////////////////////////////////////////

--- a/trinity/Eve/SpaceObject/EveSwarm.cpp
+++ b/trinity/Eve/SpaceObject/EveSwarm.cpp
@@ -1079,9 +1079,9 @@ void EveSwarm::EnableSwarmForceDebug( bool enable )
 }
 
 // --------------------------------------------------------------------------------
-void EveSwarm::GetLocatorInObjectSpace( Vector3& position, Vector3& direction, const Locator& locator ) const
+void EveSwarm::GetLocatorInObjectSpace( Vector3& position, Vector3& direction, const Locator& locator, int mergedDamageIndex ) const
 {
-	EveShip2::GetLocatorInObjectSpace( position, direction, locator );
+	EveShip2::GetLocatorInObjectSpace( position, direction, locator, mergedDamageIndex );
 	if( m_count )
 	{
 		Matrix localTransform = *m_renderables[m_targetIndex]->GetWorldTransform() * m_invWorldTransform;
@@ -1109,7 +1109,7 @@ bool EveSwarm::GetDamageLocatorPosition( Vector3* out, int index, bool inWorldSp
 			const Locator& damageLocator = ( *damageLocators )[index];
 
 			Vector3 position, direction;
-			GetLocatorInObjectSpace( position, direction, damageLocator );
+			GetLocatorInObjectSpace( position, direction, damageLocator, index );
 
 			if( inWorldSpace )
 			{

--- a/trinity/Eve/SpaceObject/EveSwarm.h
+++ b/trinity/Eve/SpaceObject/EveSwarm.h
@@ -254,7 +254,7 @@ public:
 protected:
 	/////////////////////////////////////////////////////////////////////////////////////
 	// Object space damage locator information
-	virtual void GetLocatorInObjectSpace( Vector3 & position, Vector3 & direction, const Locator& locator ) const;
+	virtual void GetLocatorInObjectSpace( Vector3 & position, Vector3 & direction, const Locator& locator, int mergedDamageIndex = -1 ) const;
 	virtual bool GetDamageLocatorPosition( Vector3 * out, int index, bool inWorldSpace );
 
 	/////////////////////////////////////////////////////////////////////////////////////

--- a/trinity/Eve/SpaceObject/Utils/EveLocatorSets.cpp
+++ b/trinity/Eve/SpaceObject/Utils/EveLocatorSets.cpp
@@ -2,8 +2,31 @@
 
 #include "StdAfx.h"
 #include "EveLocatorSets.h"
+#include "Tr2GrannyAnimation.h"
+#include "Utilities/MatrixUtils.h"
 
 static_assert( sizeof( EveSpaceObjectChild::PartTag ) == sizeof( uint32_t ), "Size mismatch for PartTag: need to update LocatorStructureDef" );
+
+// --------------------------------------------------------------------------------
+// Description:
+//   Get locator position and direction, transformed by animationUpdater.
+//   We're assuming for now that the bone 0 isn't animated for performance reasons.
+// --------------------------------------------------------------------------------
+void EveGetLocatorPose( const Tr2GrannyAnimation* animationUpdater, const Locator& locator, Vector3& position, Vector3& direction )
+{
+	position = locator.position;
+	direction = (Vector3)XMVector3Rotate( Vector3( 0.f, 1.f, 0.f ), locator.direction );
+
+	if( locator.boneIndex > 0 && animationUpdater && animationUpdater->IsInitialized() &&
+		locator.boneIndex < animationUpdater->GetMeshBoneCount() )
+	{
+		const Float4x3* bones = animationUpdater->GetMeshBoneMatrixList();
+		Matrix boneTF = IdentityMatrix();
+		TriMatrixCopyFrom3x4( &boneTF, &bones[locator.boneIndex] );
+		position = XMVector3TransformCoord( locator.position, boneTF );
+		direction = XMVector3TransformNormal( direction, boneTF );
+	}
+}
 
 // locator item definition
 static BlueStructureDefinition LocatorStructureDef[] = {

--- a/trinity/Eve/SpaceObject/Utils/EveLocatorSets.h
+++ b/trinity/Eve/SpaceObject/Utils/EveLocatorSets.h
@@ -17,6 +17,8 @@ struct Locator
 };
 BLUE_DECLARE_STRUCTURE_LIST( Locator );
 
+void EveGetLocatorPose( const class Tr2GrannyAnimation* animationUpdater, const Locator& locator, Vector3& position, Vector3& direction );
+
 // --------------------------------------------------------------------------------
 // Description:
 //   A set of locatorlists, identified by names


### PR DESCRIPTION
Two fixes:
1. The impact shader expects locator positions in object space. So remove bone transformation of damage locator position when it's passed to the shader.
2. Damage locators for modular ships need to apply bone transform during target selection. The merged list of damage locators therefore cannot cache the entire chain of transformations.