### PR TITLE
fix conflicting damage overlays

### DIFF
--- a/trinity/Shader/Utils/Tr2DataTextureManager.cpp
+++ b/trinity/Shader/Utils/Tr2DataTextureManager.cpp
@@ -197,7 +197,7 @@ int32_t Tr2DataTextureManager::RequestBlockData( const Vector4* headerData, uint
 	m_blockData[m_blockDataNextIdx] = bd;
 
 	// and insert it into the priority map, keeps it sorted!
-	m_blockPriority[priority] = m_blockDataNextIdx;
+	m_blockPriority.insert( std::make_pair( priority, m_blockDataNextIdx ) );
 
 	return m_blockDataNextIdx++;
 }

--- a/trinity/Shader/Utils/Tr2DataTextureManager.h
+++ b/trinity/Shader/Utils/Tr2DataTextureManager.h
@@ -63,7 +63,7 @@ private:
 	// the data
 	int32_t m_blockDataNextIdx;
 	std::map<int32_t, BlockData> m_blockData;
-	std::map<float, int32_t> m_blockPriority;
+	std::multimap<float, int32_t> m_blockPriority;
 
 	// the texture
 	Tr2TextureReferencePtr m_dataTexture;


### PR DESCRIPTION
https://fenriscreations.atlassian.net/browse/PLAT-12001
Data was overwritten by different damage overlays, causing damage impact to disappear.