### PR TITLE
Increase free disk space requirement for TC builds

### DIFF
--- a/.teamcity/MacOS/Project.kt
+++ b/.teamcity/MacOS/Project.kt
@@ -179,7 +179,7 @@ class CarbonBuildMacOS(buildName: String, configType: String, preset: String, ag
         perfmon {
         }
         freeDiskSpace {
-            requiredSpace = "10gb"
+            requiredSpace = "30gb"
             failBuild = true
         }
         sshAgent {

--- a/.teamcity/Windows/Project.kt
+++ b/.teamcity/Windows/Project.kt
@@ -237,7 +237,7 @@ class CarbonBuildWindows(buildName: String, configType: String, preset: String) 
         perfmon {
         }
         freeDiskSpace {
-            requiredSpace = "10gb"
+            requiredSpace = "30gb"
             failBuild = true
         }
         sshAgent {


### PR DESCRIPTION
Fix for TeamCity builds occasionally running out of disk space.
Increase the free disk space requirement to 30GB.